### PR TITLE
Clarify and expand the NAME documentation.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+6.63_03
+    Doc Fixes
+    * Clarified NAME. [rt.cpan.org 73361]
+    * SYNOPSIS is a bit more useful.
+
+
 6.63_02  Tue Nov  1 17:02:40 PDT 2011
     Test Fixes
     * Inform BSDPAN (on FreeBSD) to not register modules installed while

--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -1156,7 +1156,10 @@ ExtUtils::MakeMaker - Create a module Makefile
 
   use ExtUtils::MakeMaker;
 
-  WriteMakefile( ATTRIBUTE => VALUE [, ...] );
+  WriteMakefile(
+      NAME              => "Foo::Bar",
+      VERSION_FROM      => "lib/Foo/Bar.pm",
+  );
 
 =head1 DESCRIPTION
 
@@ -2013,9 +2016,18 @@ name of the library (see SDBM_File)
 
 =item NAME
 
-Perl module name for this extension (DBD::Oracle). This will default
-to the directory name but should be explicitly defined in the
-Makefile.PL.
+The package representing the distribution. For example, C<Test::More>
+or C<ExtUtils::MakeMaker>. It will be used to derive information about
+the distribution such as the L<DISTNAME>, installation locations
+within the Perl library and where XS files will be looked for by
+default (see L<XS>).
+
+C<NAME> I<must> be a valid Perl package name and it I<must> have an
+associated C<.pm> file. For example, C<Foo::Bar> is a valid C<NAME>
+and there must exist F<Foo/Bar.pm>.  Any XS code should be in
+F<Bar.xs> unless stated otherwise.
+
+Your distribution B<must> have a C<NAME>.
 
 =item NEEDS_LINKING
 


### PR DESCRIPTION
- Declare that NAME _must_ be a valid package name
- Declare that NAME _must_ have an associated .pm file

The above were always implied but never declared.
- Make the SYNOPSIS a bit more realistically useful

For [rt.cpan.org 73361](https://rt.cpan.org/Public/Bug/Display.html?id=73361)
