### PR TITLE
Standard MANIFEST.SKIP updated

### DIFF
--- a/bundled/ExtUtils-Manifest/ExtUtils/MANIFEST.SKIP
+++ b/bundled/ExtUtils-Manifest/ExtUtils/MANIFEST.SKIP
@@ -40,6 +40,7 @@
 \.tmp$
 \.#
 \.rej$
+\..*\.sw.?$
 
 # Avoid OS-specific files/dirs
 # Mac OSX metadata


### PR DESCRIPTION
...to include vim temp files, typically named .foo.swp or .foo.swo
