### PR TITLE
Fix RT #83441 -  Fix improper modification of hash during each() traversal in t/basic.t

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -412,8 +412,5 @@ close SAVERR;
 sub _normalize {
     my $hash = shift;
 
-    while(my($k,$v) = each %$hash) {
-        delete $hash->{$k};
-        $hash->{lc $k} = $v;
-    }
+    %$hash= map { lc($_) => $hash->{$_} } keys %$hash;
 }


### PR DESCRIPTION
Perl has always explicitly documented that you cannot each()
through a hash and modify the hash in any way other than
deleting an element without encountering undefined behavior.

This patches fixes a test file which has always been buggy
but due to implementation reasons in Perl has not caused trouble.

In Perl 5.18 we will introduce randomized hash traversal. The
implementation of this guarantees that this code will break hard.

This is the same patch posted in:

```
https://rt.cpan.org/Public/Bug/Display.html?id=83441
```

and also relates to:

```
https://rt.perl.org/rt3/Ticket/Display.html?id=116857
```

(but without the version bump)
