### PR TITLE
Do not hard code the list of perl header files - discover them from disk instead

### DIFF
--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -2755,10 +2755,9 @@ MAKE_FRAG
     return join "", @m unless $self->needs_linking;
 
     if ($self->{OBJECT}) {
-        my $fmt= '        $(PERL_INC)/%s            '; # preserve the old indentation and formating
-        push @m, qq{PERL_HDRS = \\\n}
-               . join("\\\n", map { sprintf $fmt, $_ } $self->_perl_header_files())
-               . qq{\n\n\$(OBJECT) : \$(PERL_HDRS)\n};
+        # Need to add an object file dependency on the perl headers.
+        # this is very important for XS modules in perl.git development.
+        push @m, $self->_perl_header_files_fragment("/"); # Directory separator between $(PERL_INC)/header.h
     }
 
     push @m, join(" ", values %{$self->{XS}})." : \$(XSUBPPDEPS)\n"  if %{$self->{XS}};

--- a/lib/ExtUtils/MM_VMS.pm
+++ b/lib/ExtUtils/MM_VMS.pm
@@ -1288,13 +1288,11 @@ sub perldepend {
     my($self) = @_;
     my(@m);
 
-# This is the same as what's done in MM_Unix except we don't put  '/' between
-# the directory and the filename as the directory already has delimiters.
     if ($self->{OBJECT}) {
-        my $fmt= '        $(PERL_INC)%s            ';
-        push @m, qq{PERL_HDRS = \\\n}
-               . join("\\\n", map { sprintf $fmt, $_ } $self->_perl_header_files())
-               . qq{\n\n\$(OBJECT) : \$(PERL_HDRS)\n};
+        # Need to add an object file dependency on the perl headers.
+        # this is very important for XS modules in perl.git development.
+
+        push @m, $self->_perl_header_files_fragment(""); # empty separator on VMS as its in the $(PERL_INC)
     }
 
     if ($self->{PERL_SRC}) {


### PR DESCRIPTION
Historically EUMM has maintained several, per OS, hard coded lists of perl
header files used to build XS modules. Over time these lists have drifted
out of sync from each other and from the actual list of headers.

This patch replaces that logic by a discovery method called

```
my @files= MM_Any->_perl_header_files();
```

which returns a list of the header files found on disk that are actually
available. MM_Unix and MM_VMS then use this to build the correct header
fragment via their perldepend() implementation.

This has been tested to work on *nix and VMS in a perl.git branch as 6.64_03.
