### PR TITLE
Remove { and } from call to Mksymlists from doc

### DIFF
--- a/lib/ExtUtils/Mksymlists.pm
+++ b/lib/ExtUtils/Mksymlists.pm
@@ -212,10 +212,10 @@ ExtUtils::Mksymlists - write linker options files for dynamic extension
 =head1 SYNOPSIS
 
     use ExtUtils::Mksymlists;
-    Mksymlists({ NAME     => $name ,
+    Mksymlists(  NAME     => $name ,
                  DL_VARS  => [ $var1, $var2, $var3 ],
                  DL_FUNCS => { $pkg1 => [ $func1, $func2 ],
-                               $pkg2 => [ $func3 ] });
+                               $pkg2 => [ $func3 ] );
 
 =head1 DESCRIPTION
 
@@ -281,9 +281,9 @@ generation of the bootstrap function for the package. To still create
 the bootstrap name you have to specify the package name in the
 DL_FUNCS hash:
 
-    Mksymlists({ NAME     => $name ,
+    Mksymlists(  NAME     => $name ,
 		 FUNCLIST => [ $func1, $func2 ],
-                 DL_FUNCS => { $pkg => [] } });
+                 DL_FUNCS => { $pkg => [] } );
 
 
 =item IMPORTS


### PR DESCRIPTION
The function seems to expect a hash, but the documentation shows a hash reference.
