### PR TITLE
doc: Fix the META_MERGE example

### DIFF
--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -2037,10 +2037,14 @@ you want to use.
 
     "meta-spec" => { version => 2 },
 
-    repository => {
-      type => 'git',
-      url => 'git://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker.git',
-      web => 'https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker',
+    resources => {
+
+      repository => {
+          type => 'git',
+          url => 'git://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker.git',
+          web => 'https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker',
+      },
+
     },
 
   },


### PR DESCRIPTION
The META_MERGE example creates `x_repository` instead of `resources => repository`.

It would be interesting to look into CPAN for broken META.{yml,json} due to copy/paste from this broken example...
