### PR TITLE
MYMETA's runtime requires is always overwritten by PREREQ_PM 

### DIFF
--- a/lib/ExtUtils/MM_Any.pm
+++ b/lib/ExtUtils/MM_Any.pm
@@ -1087,7 +1087,7 @@ sub _add_requirements_to_meta_v2 {
     }
 
     $meta{prereqs}{runtime}{requires} = _normalize_prereqs($self->{PREREQ_PM})
-        if defined $self->{PREREQ_PM};
+        if $self->{ARGS}{PREREQ_PM};
     $meta{prereqs}{runtime}{requires}{perl} = _normalize_version($self->{MIN_PERL_VERSION})
         if $self->{MIN_PERL_VERSION};
 


### PR DESCRIPTION
When you have a complete (static) list of prereqs in `META.json` and do not pass `PREREQ_PM` in `WriteMakefile()`, I expect MakeMaker to preserve these prereqs when dumping to MYMETA.json, like prereqs in other types/phases, but it doesn't.

There's the following code in MM_Any.pm:

```
    $meta{prereqs}{runtime}{requires} = _normalize_prereqs($self->{PREREQ_PM})
        if defined $self->{PREREQ_PM};
    $meta{prereqs}{runtime}{requires}{perl} = _normalize_version($self->{MIN_PERL_VERSION})
        if $self->{MIN_PERL_VERSION};
```

however `$self->{PREREQ_PM}` is always initialized as an empty hash ref when it is not given (or undef), so this `if` condition never becomes false.

For other requirement phases like test or build, there's a check if the parameter exists in `$self->{ARGS}` as well, to distinguish whether an empty was given from user or empty was initialized by the module internals.

I wonder if that defined check should be changed to `$self->{ARGS}{PREREQ_PM}` as well.
