### PR TITLE
skip some tests when cross-compiling

### DIFF
--- a/t/INSTALL_BASE.t
+++ b/t/INSTALL_BASE.t
@@ -10,9 +10,18 @@ use strict;
 use File::Path;
 use Config;
 
-use Test::More tests => 20;
+use Test::More;
 use MakeMaker::Test::Utils;
 use MakeMaker::Test::Setup::BFD;
+
+my $Skipped = 0;
+if( $Config{'usecrosscompile'} ) {
+    $Skipped = 1;
+    plan skip_all => "no toolchain installed when cross-compiling";
+}
+else {
+    plan tests => 20;
+}
 
 my $Is_VMS = $^O eq 'VMS';
 
@@ -23,8 +32,10 @@ perl_lib;
 
 ok( setup_recurs(), 'setup' );
 END {
-    ok( chdir File::Spec->updir );
-    ok( teardown_recurs(), 'teardown' );
+    unless ( $Skipped ) {
+        ok( chdir File::Spec->updir );
+        ok( teardown_recurs(), 'teardown' );
+    }
 }
 
 ok( chdir('Big-Dummy'), "chdir'd to Big-Dummy") || diag("chdir failed; $!");

--- a/t/PL_FILES.t
+++ b/t/PL_FILES.t
@@ -6,11 +6,21 @@ BEGIN {
 chdir 't';
 
 use strict;
-use Test::More tests => 9;
+use Config;
+use Test::More;
 
 use File::Spec;
 use MakeMaker::Test::Setup::PL_FILES;
 use MakeMaker::Test::Utils;
+
+my $Skipped = 0;
+if( $Config{'usecrosscompile'} ) {
+    $Skipped = 1;
+    plan skip_all => "no toolchain installed when cross-compiling";
+}
+else {
+    plan tests => 9;
+}
 
 my $perl = which_perl();
 my $make = make_run();
@@ -19,8 +29,10 @@ perl_lib();
 setup;
 
 END {
-    ok( chdir File::Spec->updir );
-    ok( teardown );
+    unless ( $Skipped ) {
+        ok( chdir File::Spec->updir );
+        ok( teardown );
+    }
 }
 
 ok chdir('PL_FILES-Module');

--- a/t/basic.t
+++ b/t/basic.t
@@ -11,12 +11,21 @@ use strict;
 use Config;
 use ExtUtils::MakeMaker;
 
-use Test::More tests => 171;
+use Test::More;
 use MakeMaker::Test::Utils;
 use MakeMaker::Test::Setup::BFD;
 use File::Find;
 use File::Spec;
 use File::Path;
+
+my $Skipped = 0;
+if( $Config{'usecrosscompile'} ) {
+    $Skipped = 1;
+    plan skip_all => "no toolchain installed when cross-compiling";
+}
+else {
+    plan tests => 171;
+}
 
 my $perl = which_perl();
 my $Is_VMS = $^O eq 'VMS';
@@ -31,8 +40,10 @@ $| = 1;
 
 ok( setup_recurs(), 'setup' );
 END {
-    ok chdir File::Spec->updir or die;
-    ok teardown_recurs, "teardown";
+    unless ( $Skipped ) {
+        ok chdir File::Spec->updir or die;
+        ok teardown_recurs, "teardown";
+    }
 }
 
 ok( chdir('Big-Dummy'), "chdir'd to Big-Dummy" ) ||

--- a/t/echo.t
+++ b/t/echo.t
@@ -16,6 +16,8 @@ use Cwd 'abs_path';
 
 use Test::More;
 
+plan skip_all => "no toolchain installed when cross-compiling"
+    if $Config{'usecrosscompile'};
 
 #--------------------- Setup
 

--- a/t/min_perl_version.t
+++ b/t/min_perl_version.t
@@ -8,7 +8,8 @@ BEGIN {
 }
 
 use strict;
-use Test::More tests => 32;
+use Config;
+use Test::More;
 
 use TieOut;
 use MakeMaker::Test::Utils;
@@ -16,6 +17,15 @@ use MakeMaker::Test::Setup::MPV;
 use File::Path;
 
 use ExtUtils::MakeMaker;
+
+my $Skipped = 0;
+if( $Config{'usecrosscompile'} ) {
+    $Skipped = 1;
+    plan skip_all => "no toolchain installed when cross-compiling";
+}
+else {
+    plan tests => 32;
+}
 
 # avoid environment variables interfering with our make runs
 delete @ENV{qw(LIB MAKEFLAGS)};
@@ -30,8 +40,10 @@ perl_lib();
 
 ok( setup_recurs(), 'setup' );
 END {
-    ok( chdir(File::Spec->updir), 'leaving dir' );
-    ok( teardown_recurs(), 'teardown' );
+    unless ( $Skipped ) {
+        ok( chdir(File::Spec->updir), 'leaving dir' );
+        ok( teardown_recurs(), 'teardown' );
+    }
 }
 
 ok( chdir 'Min-PerlVers', 'entering dir Min-PerlVers' ) ||
@@ -145,7 +157,7 @@ note "PRINT_PREREQ output"; {
 note "generated files verification"; {
     unlink $makefile;
     my @mpl_out = run(qq{$perl Makefile.PL});
-    END { unlink $makefile, makefile_backup() }
+    END { unlink $makefile, makefile_backup() unless $Skipped }
 
     cmp_ok( $?, '==', 0, 'Makefile.PL exiting normally' ) || diag(@mpl_out);
     ok( -e $makefile, 'Makefile present' );
@@ -155,7 +167,7 @@ note "generated files verification"; {
 note "ppd output"; {
     my $ppd_file = 'Min-PerlVers.ppd';
     my @make_out = run(qq{$make ppd});
-    END { unlink $ppd_file }
+    END { unlink $ppd_file unless $Skipped }
 
     cmp_ok( $?, '==', 0,    'Make ppd exiting normally' ) || diag(@make_out);
 
@@ -174,7 +186,7 @@ note "META.yml output"; {
     my $meta_yml = "$distdir/META.yml";
     my $meta_json = "$distdir/META.json";
     my @make_out    = run(qq{$make metafile});
-    END { rmtree $distdir }
+    END { rmtree $distdir unless $Skipped }
 
     for my $case (
         ['META.yml', $meta_yml],

--- a/t/miniperl.t
+++ b/t/miniperl.t
@@ -6,12 +6,16 @@
 use strict;
 use lib 't/lib';
 
+use Config;
 use Test::More;
 
 # In a BEGIN block so the END tests aren't registered.
 BEGIN {
     plan skip_all => "miniperl test only necessary for the perl core"
       if !$ENV{PERL_CORE};
+
+    plan skip_all => "no toolchain installed when cross-compiling"
+      if $Config{'usecrosscompile'};
 
     plan "no_plan";
 }
@@ -42,8 +46,10 @@ my $make     = make_run();
 
     ok( setup_recurs(), 'setup' );
     END {
-        ok( chdir File::Spec->updir );
-        ok( teardown_recurs(), 'teardown' );
+        unless ( $Skipped ) {
+            ok( chdir File::Spec->updir );
+            ok( teardown_recurs(), 'teardown' );
+        }
     }
 
     ok( chdir('Big-Dummy'), "chdir'd to Big-Dummy" ) ||

--- a/t/pm_to_blib.t
+++ b/t/pm_to_blib.t
@@ -5,12 +5,22 @@
 use strict;
 use lib 't/lib';
 
-use Test::More 'no_plan';
+use Config;
+use Test::More;
 
 use ExtUtils::MakeMaker;
 
 use MakeMaker::Test::Utils;
 use MakeMaker::Test::Setup::BFD;
+
+my $Skipped = 0;
+if( $Config{'usecrosscompile'} ) {
+    $Skipped = 1;
+    plan skip_all => "no toolchain installed when cross-compiling";
+}
+else {
+    plan 'no_plan';
+}
 
 
 my $perl     = which_perl();
@@ -26,8 +36,10 @@ my $make     = make_run();
 
     ok( setup_recurs(), 'setup' );
     END {
-        ok( chdir File::Spec->updir );
-        ok( teardown_recurs(), 'teardown' );
+        unless ( $Skipped ) {
+            ok( chdir File::Spec->updir );
+            ok( teardown_recurs(), 'teardown' );
+        }
     }
 
     ok( chdir('Big-Dummy'), "chdir'd to Big-Dummy" ) ||

--- a/t/recurs.t
+++ b/t/recurs.t
@@ -9,9 +9,18 @@ BEGIN {
 use strict;
 use Config;
 
-use Test::More tests => 26;
+use Test::More;
 use MakeMaker::Test::Utils;
 use MakeMaker::Test::Setup::Recurs;
+
+my $Skipped = 0;
+if( $Config{'usecrosscompile'} ) {
+    $Skipped = 1;
+    plan skip_all => "no toolchain installed when cross-compiling";
+}
+else {
+    plan tests => 26;
+}
 
 # 'make disttest' sets a bunch of environment variables which interfere
 # with our testing.
@@ -30,8 +39,10 @@ $| = 1;
 
 ok( setup_recurs(), 'setup' );
 END {
-    ok( chdir File::Spec->updir );
-    ok( teardown_recurs(), 'teardown' );
+    unless ( $Skipped ) {
+        ok( chdir File::Spec->updir );
+        ok( teardown_recurs(), 'teardown' );
+    }
 }
 
 ok( chdir('Recurs'), q{chdir'd to Recurs} ) ||


### PR DESCRIPTION
the toolchain is not installed on the target when cross-compiling.
there are no sense to install this module on target, but EUMM is a part of Perl distribution.
so that fixes the Perl test suite when cross-compiling.
