### PR TITLE
skip some tests when cross-compiling V4

### DIFF
--- a/t/INSTALL_BASE.t
+++ b/t/INSTALL_BASE.t
@@ -10,12 +10,13 @@ use strict;
 use File::Path;
 use Config;
 
-use Test::More
-    $ENV{PERL_CORE} && $Config{'usecrosscompile'}
-    ? (skip_all => "no toolchain installed when cross-compiling")
-    : (tests => 20);
 use MakeMaker::Test::Utils;
 use MakeMaker::Test::Setup::BFD;
+use IPC::Cmd qw(can_run);
+use Test::More
+    can_run(make())
+    ? (tests => 20)
+    : (skip_all => "make not available");
 
 my $Is_VMS = $^O eq 'VMS';
 

--- a/t/PL_FILES.t
+++ b/t/PL_FILES.t
@@ -6,15 +6,15 @@ BEGIN {
 chdir 't';
 
 use strict;
-use Config;
-use Test::More
-    $ENV{PERL_CORE} && $Config{'usecrosscompile'}
-    ? (skip_all => "no toolchain installed when cross-compiling")
-    : (tests => 9);
 
 use File::Spec;
 use MakeMaker::Test::Setup::PL_FILES;
 use MakeMaker::Test::Utils;
+use IPC::Cmd qw(can_run);
+use Test::More
+    can_run(make())
+    ? (tests => 9)
+    : (skip_all => "make not available");
 
 my $perl = which_perl();
 my $make = make_run();

--- a/t/basic.t
+++ b/t/basic.t
@@ -11,12 +11,13 @@ use strict;
 use Config;
 use ExtUtils::MakeMaker;
 
-use Test::More
-    $ENV{PERL_CORE} && $Config{'usecrosscompile'}
-    ? (skip_all => "no toolchain installed when cross-compiling")
-    : (tests => 171);
 use MakeMaker::Test::Utils;
 use MakeMaker::Test::Setup::BFD;
+use IPC::Cmd qw(can_run);
+use Test::More
+    can_run(make())
+    ? (tests => 171)
+    : (skip_all => "make not available");
 use File::Find;
 use File::Spec;
 use File::Path;

--- a/t/echo.t
+++ b/t/echo.t
@@ -13,11 +13,12 @@ use ExtUtils::MM;
 use MakeMaker::Test::Utils;
 use File::Temp;
 use Cwd 'abs_path';
+use IPC::Cmd 'can_run';
 
 use Test::More;
 
-plan skip_all => "no toolchain installed when cross-compiling"
-    if $ENV{PERL_CORE} && $Config{'usecrosscompile'};
+plan skip_all => "make not available"
+    unless can_run(make());
 
 #--------------------- Setup
 

--- a/t/min_perl_version.t
+++ b/t/min_perl_version.t
@@ -8,15 +8,15 @@ BEGIN {
 }
 
 use strict;
-use Config;
-use Test::More
-    $ENV{PERL_CORE} && $Config{'usecrosscompile'}
-    ? (skip_all => "no toolchain installed when cross-compiling")
-    : (tests => 32);
 
 use TieOut;
 use MakeMaker::Test::Utils;
 use MakeMaker::Test::Setup::MPV;
+use IPC::Cmd qw(can_run);
+use Test::More
+    can_run(make())
+    ? (tests => 32)
+    : (skip_all => "make not available");
 use File::Path;
 
 use ExtUtils::MakeMaker;

--- a/t/miniperl.t
+++ b/t/miniperl.t
@@ -6,16 +6,18 @@
 use strict;
 use lib 't/lib';
 
-use Config;
 use Test::More;
+use IPC::Cmd qw(can_run);
+use MakeMaker::Test::Utils;
+use MakeMaker::Test::Setup::BFD;
 
 # In a BEGIN block so the END tests aren't registered.
 BEGIN {
     plan skip_all => "miniperl test only necessary for the perl core"
       if !$ENV{PERL_CORE};
 
-    plan skip_all => "no toolchain installed when cross-compiling"
-      if $ENV{PERL_CORE} && $Config{'usecrosscompile'};
+    plan skip_all => "make not available"
+      unless can_run(make());
 
     plan "no_plan";
 }
@@ -28,9 +30,6 @@ BEGIN {
 use MakeMaker::Test::NoXS;
 
 use ExtUtils::MakeMaker;
-
-use MakeMaker::Test::Utils;
-use MakeMaker::Test::Setup::BFD;
 
 
 my $perl     = which_perl();

--- a/t/pm_to_blib.t
+++ b/t/pm_to_blib.t
@@ -5,17 +5,17 @@
 use strict;
 use lib 't/lib';
 
-use Config;
-use Test::More
-    $ENV{PERL_CORE} && $Config{'usecrosscompile'}
-    ? (skip_all => "no toolchain installed when cross-compiling")
-    : 'no_plan';
 use File::Temp qw[tempdir];
 
 use ExtUtils::MakeMaker;
 
 use MakeMaker::Test::Utils;
 use MakeMaker::Test::Setup::BFD;
+use IPC::Cmd qw(can_run);
+use Test::More
+    can_run(make())
+    ? 'no_plan'
+    : (skip_all => "make not available");
 
 
 my $perl     = which_perl();

--- a/t/recurs.t
+++ b/t/recurs.t
@@ -9,14 +9,15 @@ BEGIN {
 use strict;
 use Config;
 
-use Test::More
-    $ENV{PERL_CORE} && $Config{'usecrosscompile'}
-    ? (skip_all => "no toolchain installed when cross-compiling")
-    : (tests => 26);
 use File::Temp qw[tempdir];
 
 use MakeMaker::Test::Utils;
 use MakeMaker::Test::Setup::Recurs;
+use IPC::Cmd qw(can_run);
+use Test::More
+    can_run(make())
+    ? (tests => 26)
+    : (skip_all => "make not available");
 
 # 'make disttest' sets a bunch of environment variables which interfere
 # with our testing.

--- a/t/several_authors.t
+++ b/t/several_authors.t
@@ -8,15 +8,15 @@ BEGIN {
 }
 
 use strict;
-use Config;
-use Test::More
-    $ENV{PERL_CORE} && $Config{'usecrosscompile'}
-    ? (skip_all => "no toolchain installed when cross-compiling")
-    : (tests => 20);
 
 use TieOut;
 use MakeMaker::Test::Utils;
 use MakeMaker::Test::Setup::SAS;
+use IPC::Cmd qw(can_run);
+use Test::More
+    can_run(make())
+    ? (tests => 20)
+    : (skip_all => "make not available");
 use File::Path;
 
 use ExtUtils::MakeMaker;


### PR DESCRIPTION
after seen the discussion on p5p about my ticket https://rt.perl.org/rt3/Public/Bug/Display.html?id=119769 , I refactor the condition with `can_run(make())`.
