### PR TITLE
do not set default switches in Test::Harness; not even -w

### DIFF
--- a/lib/ExtUtils/MM_Any.pm
+++ b/lib/ExtUtils/MM_Any.pm
@@ -2366,8 +2366,8 @@ Used on the t/*.t files.
 sub test_via_harness {
     my($self, $perl, $tests) = @_;
 
-    return qq{\t$perl "-MExtUtils::Command::MM" }.
-           qq{"-e" "test_harness(\$(TEST_VERBOSE), '\$(INST_LIB)', '\$(INST_ARCHLIB)')" $tests\n};
+    return qq{\t$perl "-MExtUtils::Command::MM" "-MTest::Harness" }.
+           qq{"-e" "undef *Test::Harness::Switches; test_harness(\$(TEST_VERBOSE), '\$(INST_LIB)', '\$(INST_ARCHLIB)')" $tests\n};
 }
 
 =head3 test_via_script


### PR DESCRIPTION
This commit is meant to address https://github.com/Perl-Toolchain-Gang/Test-Harness/wiki/TAP::Harness-and--the-w-flag

Rather than change Test::Harness, the compatibility layer for TAP::Harness, this changes the actual thing we have been complaining about: `make test` turning on -w globally.
