### PR TITLE
unify library linking step 1

### DIFF
--- a/lib/ExtUtils/MM_OS2.pm
+++ b/lib/ExtUtils/MM_OS2.pm
@@ -91,18 +91,20 @@ $self->{BASEEXT}.def: Makefile.PL
     join('',@m);
 }
 
-sub static_lib {
-    my($self) = @_;
-    my $old = $self->ExtUtils::MM_Unix::static_lib();
-    return $old unless $self->{IMPORTS} && %{$self->{IMPORTS}};
+=item static_lib_template
 
-    my @chunks = split /\n{2,}/, $old;
-    shift @chunks unless length $chunks[0]; # Empty lines at the start
-    $chunks[0] .= <<'EOC';
+Defines how to produce any *.lib (or equivalent) files.
 
-	$(AR) $(AR_STATIC_ARGS) $@ tmp_imp/* && $(RANLIB) $@
-EOC
-    return join "\n\n". '', @chunks;
+=cut
+
+sub static_lib_template
+{
+    my ($self, $target, $deps, $src, $fixtures, $closures) = @_;
+
+    my @m = $self->ExtUtils::MM_Unix::static_lib_template($target, $deps, $src, $fixtures, $closures);
+    push @m, q{	$(AR) $(AR_STATIC_ARGS) $@ tmp_imp/* && $(RANLIB) $@};
+
+    return @m;
 }
 
 sub replace_manpage_separator {

--- a/lib/ExtUtils/MM_Win32.pm
+++ b/lib/ExtUtils/MM_Win32.pm
@@ -280,48 +280,21 @@ MAKE_FRAG
     return $make_frag;
 }
 
+=item static_lib_pure_cmd
 
-=item static_lib
-
-Changes how to run the linker.
-
-The rest is duplicate code from MM_Unix.  Should move the linker code
-to its own method.
+Defines how to run the archive utility
 
 =cut
 
-sub static_lib {
-    my($self) = @_;
-    return '' unless $self->has_link_code;
+sub static_lib_pure_cmd
+{
+    my ($self, $src) = @_;
 
-    my(@m);
-    push(@m, <<'END');
-$(INST_STATIC): $(OBJECT) $(MYEXTLIB) $(INST_ARCHAUTODIR)$(DFSEP).exists
-	$(RM_RF) $@
-END
-
-    # If this extension has its own library (eg SDBM_File)
-    # then copy that to $(INST_STATIC) and add $(OBJECT) into it.
-    push @m, <<'MAKE_FRAG' if $self->{MYEXTLIB};
-	$(CP) $(MYEXTLIB) $@
-MAKE_FRAG
-
-    push @m,
-q{	$(AR) }.($BORLAND ? '$@ $(OBJECT:^"+")'
-			  : ($GCC ? '-ru $@ $(OBJECT)'
-			          : '-out:$@ $(OBJECT)')).q{
-	$(CHMOD) $(PERM_RWX) $@
-	$(NOECHO) $(ECHO) "$(EXTRALIBS)" > $(INST_ARCHAUTODIR)\extralibs.ld
-};
-
-    # Old mechanism - still available:
-    push @m, <<'MAKE_FRAG' if $self->{PERL_SRC} && $self->{EXTRALIBS};
-	$(NOECHO) $(ECHO) "$(EXTRALIBS)" >> $(PERL_SRC)\ext.libs
-MAKE_FRAG
-
-    join('', @m);
+    $BORLAND and $src =~ s/(\$\(\w+)(\))/$1:^"+"$2/g;
+    return q{	$(AR) }.($BORLAND ? '$@ ' . $src
+			  : ($GCC ? '-ru $@ ' . $src
+			          : '-out:$@ ' . $src));
 }
-
 
 =item dynamic_lib
 


### PR DESCRIPTION
As discussed last week with leont in #toolchain - it's currently very difficult to create multiple loadable modules in on directory (using one Makefile.PL).

This is a request for comment whether the direction of movement is right before investing to much effort.

Missing: VMS

Next steps: create OS/2 VM, Win32 VM (or recruit Mithaldu) and install OpenVMS as described in http://www.heise.de/ix/artikel/Dolly-Digital-1355065.html (using FreeAXP?)...

Then do the same for dynamic_lib