### PR TITLE
harden xsubpp locating loop in MM_Unix

### DIFF
--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -3504,12 +3504,15 @@ sub tool_xsubpp {
     # Make sure we pick up the new xsubpp if we're building perl.
     unshift @xsubpp_dirs, $self->{PERL_LIB} if $self->{PERL_CORE};
 
+    my $foundxsubpp = 0;
     foreach my $dir (@xsubpp_dirs) {
         $xsdir = $self->catdir($dir, 'ExtUtils');
         if( -r $self->catfile($xsdir, "xsubpp") ) {
+            $foundxsubpp = 1;
             last;
         }
     }
+    die "ExtUtils::MM_Unix::tool_xsubpp : Can't find xsubpp" if !$foundxsubpp;
 
     my $tmdir   = File::Spec->catdir($self->{PERL_LIB},"ExtUtils");
     my(@tmdeps) = $self->catfile($tmdir,'typemap');


### PR DESCRIPTION
While working on the WinCE interp build process, at one point xsubpp
wasn't in @INC or buildcustomize.pl, and EUMM silently continued and placed
a non-existant path into XSUBPPDIR in the makefile even though it never
found xsubpp.
