### PR TITLE
Doc: mention that TEST_REQUIRES is in v6.64 and above

### DIFF
--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -2610,6 +2610,8 @@ if you really need it.
 
 =item TEST_REQUIRES
 
+Available in version 6.64 and above.
+
 A hash of modules that are needed to test your module but not run or
 build it.
 


### PR DESCRIPTION
Minor doc tweak. The doc says which version introduced the other _REQUIRES fields, but not for TEST_REQUIRES. This adds a line saying that the field is available in 6.64 and above.
