### PR TITLE
ExtUtils::MM_Any: Get rid of unused printf arguments in dir_target

### DIFF
--- a/lib/ExtUtils/MM_Any.pm
+++ b/lib/ExtUtils/MM_Any.pm
@@ -643,7 +643,7 @@ sub dir_target {
 
     my $make = '';
     foreach my $dir (@dirs) {
-        $make .= sprintf <<'MAKE', ($dir) x 7;
+        $make .= sprintf <<'MAKE', ($dir) x 4;
 %s$(DFSEP).exists :: Makefile.PL
 	$(NOECHO) $(MKPATH) %s
 	$(NOECHO) $(CHMOD) $(PERM_DIR) %s


### PR DESCRIPTION
These printf arguments have been in flux since 0f2e87e, but although we
had 6 at that point they were quickly chopped down to 4 in 2f9a3b6 and
have remained at that number ever since.

Change the code not to provide redundant arguments that it doesn't have
to. Found with a nascent patch of mine to the core to detect redundant
printf arguments: https://rt.perl.org/Public/Bug/Display.html?id=121025
