### PR TITLE
ExtUtils::MM_Unix: Get rid of unused printf arguments in dynamic_bs

### DIFF
--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -866,7 +866,7 @@ BOOTSTRAP =
 
     my $target = $Is{VMS} ? '$(MMS$TARGET)' : '$@';
 
-    return sprintf <<'MAKE_FRAG', ($target) x 5;
+    return sprintf <<'MAKE_FRAG', ($target) x 2;
 BOOTSTRAP = $(BASEEXT).bs
 
 # As Mkbootstrap might not write a file (if none is required)


### PR DESCRIPTION
The issue with redundant printf arguments that I noted in
v6.67_01-222-g32a5d25 for ExtUtils::MM_Any::dir_target() also exists for
ExtUtils::MM_Unix::dynamic_bs(). Fix that very minor issue too by
getting rid of the unused arguments.

We've been passing the wrong number of arguments to this function every
since three of them were removed in v6.67_01-157-g1364164.
