### PR TITLE
typemaps file paths may have spaces, escape/quote if necessery

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+6.99_01 Sat May 10 3:24:10 EST 2014
+    When typemaps containing whitespace were passed in under TYPEMAPS array ref,
+    the typemap entries were broken up into separate paths to try on the command
+    line to xsubpp, and none of the "NEW" paths resulted in xsubpp finding any
+    typemaps. This was fix.
+
 6.98 Tue Apr 29 21:27:59 BST 2014
 
     No changes from 6.97_02

--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -3544,6 +3544,8 @@ sub tool_xsubpp {
             }
         }
     }
+    #escape whitespace on typemap file paths (esp win32)
+    foreach(@tmdeps) {$_ = $self->quote_literal($_)};
     push(@tmdeps, "typemap") if -f "typemap";
     my(@tmargs) = map("-typemap $_", @tmdeps);
     if( exists $self->{XSOPT} ){


### PR DESCRIPTION
I only tested this on on Win32. quote_literal() has a different
implementation on *nix vs windows, but I think both "do the right thing"
