### PR TITLE
Perl version support policy = 5.8.1+ but accept 5.6 patches.

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,10 @@
 This is a CPAN distribution of the venerable MakeMaker module.  It has been
 backported to work with Perl 5.6.0 and up.
 
+Please note that while this module works on Perl 5.6, it is no longer
+being routinely tested on 5.6. However, patches to repair any breakage
+on 5.6 are still being accepted.
+
 See INSTALL for installation instructions.  Run "perldoc
 ExtUtils::MakeMaker" (while in this source directory before
 installation) for more documentation.

--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -3152,6 +3152,12 @@ If no $default is provided an empty string will be used instead.
 
 =back
 
+=head2 Supported versions of Perl
+
+Please note that while this module works on Perl 5.6, it is no longer
+being routinely tested on 5.6 - the earliest Perl version being routinely
+tested, and expressly supported, is 5.8.1. However, patches to repair
+any breakage on 5.6 are still being accepted.
 
 =head1 ENVIRONMENT
 


### PR DESCRIPTION
Intended to resolve #5.
