### PR TITLE
allow blead and 5.6.2 to fail on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ notifications:
   irc: "irc.perl.org#makemaker"
   email: false
 perl:
-  - "5.6.2"
   - "5.8.1"
   - "5.8.5"
   - "5.8.7"
@@ -22,7 +21,10 @@ perl:
   - "5.18.0"
   - "5.18"
   - "5.20"
-  - "blead"
+matrix:
+  allow_failures:
+    - perl: "blead"
+    - perl: "5.6.2"
 before_install:
   - git clone git://github.com/haarg/perl-travis-helper ~/perl-travis-helper
   - source ~/perl-travis-helper/init


### PR DESCRIPTION
Allow perl 5.6.2 and blead to fail on travis without failing the entire build.  This matches with the policy of 5.8.1 as the minimum supported version, but still helps anyone who wants to provide patches to make it work on earlier versions.

blead fails to build often enough that it shouldn't cause the entire build to be rejected.
