### PR TITLE
Mksymlists: dont produce Borland C export symbols if BCC support dropped

### DIFF
--- a/lib/ExtUtils/Mksymlists.pm
+++ b/lib/ExtUtils/Mksymlists.pm
@@ -141,19 +141,24 @@ sub _write_win32 {
     print $def "EXPORTS\n  ";
     my @syms;
     # Export public symbols both with and without underscores to
-    # ensure compatibility between DLLs from different compilers
+    # ensure compatibility between DLLs from Borland C and Visual C
     # NOTE: DynaLoader itself only uses the names without underscores,
     # so this is only to cover the case when the extension DLL may be
     # linked to directly from C. GSAR 97-07-10
-    if ($Config::Config{'cc'} =~ /^bcc/i) {
-        for (@{$data->{DL_VARS}}, @{$data->{FUNCLIST}}) {
-            push @syms, "_$_", "$_ = _$_";
+
+    #bcc dropped in 5.16, so dont create useless extra symbols for export table
+    unless($] >= 5.016) {
+        if ($Config::Config{'cc'} =~ /^bcc/i) {
+            push @syms, "_$_", "$_ = _$_"
+                for (@{$data->{DL_VARS}}, @{$data->{FUNCLIST}});
         }
-    }
-    else {
-        for (@{$data->{DL_VARS}}, @{$data->{FUNCLIST}}) {
-            push @syms, "$_", "_$_ = $_";
+        else {
+            push @syms, "$_", "_$_ = $_"
+                for (@{$data->{DL_VARS}}, @{$data->{FUNCLIST}});
         }
+    } else {
+        push @syms, "$_"
+            for (@{$data->{DL_VARS}}, @{$data->{FUNCLIST}});
     }
     print $def join("\n  ",@syms, "\n") if @syms;
     _print_imports($def, $data);


### PR DESCRIPTION
I am unable to do a "make test" on my patch in EUMM repo because EUMM github master fails very badly, so it has only been tested in my P5P blead repo.

Borland C was dropped in Perl 5.16. Underscore prefixed symbols were added
for interworking between BCC DLLs and VC DLLs in P5P ML post
"[PATCH] binary coexistence on win32" by Gurusamy Sarathy. Remove
underscore prefixed symbols if BCC support is impossible on a particular
perl version. This removed a RO litteral string, plus some void \* sized
slices in the export table, from every DLL image making them smaller.
