### PR TITLE
Make prereq-handling still work (minus version-range) if no CMR

### DIFF
--- a/t/prereq.t
+++ b/t/prereq.t
@@ -55,14 +55,18 @@ ok( chdir 'Big-Dummy', "chdir'd to Big-Dummy" ) ||
     );
     is $warnings, '';
 
-    $warnings = '';
-    WriteMakefile(
-        NAME            => 'Big::Dummy',
-        PREREQ_PM       => {
-            strict  =>  '>= 0, <= 99999',
-        }
-    );
-    is $warnings, '', 'version range';
+    SKIP: {
+	skip 'No CMR, no version ranges', 1
+	    unless ExtUtils::MakeMaker::_has_cpan_meta_requirements;
+	$warnings = '';
+	WriteMakefile(
+	    NAME            => 'Big::Dummy',
+	    PREREQ_PM       => {
+		strict  =>  '>= 0, <= 99999',
+	    }
+	);
+	is $warnings, '', 'version range';
+    }
 
     $warnings = '';
     WriteMakefile(


### PR DESCRIPTION
Using PR for visibility, but per #toolchain discussion will merge straight into master (after travis check) so can test against perl blead (where CMR might not yet be available) before rebasing XSMULTI against it ready for smoke-testing.
