### PR TITLE
Revert Liblist to a working state

### DIFF
--- a/lib/ExtUtils/Liblist/Kid.pm
+++ b/lib/ExtUtils/Liblist/Kid.pm
@@ -107,6 +107,7 @@ sub _unix_os2_ext {
 
         my ( $found_lib ) = 0;
         foreach my $thispth ( @searchpath, @libpath ) {
+
             # Try to find the full name of the library.  We need this to
             # determine whether it's a dynamically-loadable library or not.
             # This tends to be subject to various os-specific quirks.
@@ -259,10 +260,6 @@ sub _unix_os2_ext {
         return ( '', '', '', '', ( $give_libs ? \@libs : () ) );
     }
     else {
-        # make sure paths with spaces are properly quoted
-        @extralibs = map { qq["$_"] } @extralibs;
-        @ldloadlibs = map { qq["$_"] } @ldloadlibs;
-
         return ( "@extralibs", "@bsloadlibs", "@ldloadlibs", join( ":", @ld_run_path ), ( $give_libs ? \@libs : () ) );
     }
 }

--- a/t/Liblist_Kid.t
+++ b/t/Liblist_Kid.t
@@ -12,14 +12,6 @@ BEGIN {
     package MockEUMM;
     use base 'File::Spec';    # what.
     sub new { return bless {}, 'MockEUMM'; }
-    sub lsdir { # cut'n'paste from LibList::Kid
-        shift;
-        my $rex = qr/$_[1]/;
-        opendir DIR, $_[0];
-        my @out = grep /$rex/, readdir DIR;
-        closedir DIR;
-        return @out;
-    }
 }
 
 package liblist_kid_test;
@@ -27,10 +19,6 @@ package liblist_kid_test;
 use Test::More 'no_plan';
 use ExtUtils::MakeMaker::Config;
 use File::Spec;
-use Cwd;
-
-# similar to dispatching in EU::LL::Kid
-my $OS = $^O eq 'MSWin32' ? 'win32' : ($^O eq 'VMS' ? 'vms' : 'unix_os2');
 
 run();
 
@@ -38,42 +26,20 @@ exit;
 
 sub run {
     use_ok( 'ExtUtils::Liblist::Kid' );
-    my $old_dir = getcwd;
-    my $cleanup = move_to_os_test_data_dir();
+    move_to_os_test_data_dir();
     conf_reset();
-    test_common();
-    test_kid_unix_os2() if $OS eq 'unix_os2';
-    test_kid_win32() if $OS eq 'win32';
-    chdir $old_dir;
-    cleanup_os_test_data_dir($cleanup) if $cleanup;
+    return test_kid_win32() if $^O eq 'MSWin32';
+    return;
 }
 
 # This allows us to get a clean playing field and ensure that the current
 # system configuration does not affect the test results.
 
 sub conf_reset {
-    my @save_keys = qw{ so dlsrc osname };
-    my %save_config;
-    @save_config{ @save_keys } = @Config{ @save_keys };
     delete $Config{$_} for keys %Config;
-    %Config = %save_config;
-    $Config{installarchlib} = 'lib';
-    # The following are all used and always are defined in the real world.
-    # Define them to something here to avoid spewing uninitialized value warnings.
-    $Config{perllibs}    = '';
-    if ($^O eq 'VMS') {
-        $Config{ldflags}     = '';
-        $Config{dbgprefix}   = '';
-        $Config{libc}        = '';
-        $Config{ext_ext}     = '';
-        $Config{lib_ext}     = '';
-        $Config{obj_ext}     = '';
-        $Config{so}          = '';
-        $Config{vms_cc_type} = '';
-        $Config{libpth}      = '';
-    }
     delete $ENV{LIB};
     delete $ENV{LIBRARY_PATH};
+
     return;
 }
 
@@ -81,27 +47,11 @@ sub conf_reset {
 # separation of OS-specific files.
 
 sub move_to_os_test_data_dir {
-    my %os_test_dirs = (
-        win32 => 't/liblist/win32',
-        unix_os2 => 't/liblist/unix_os2',
-    );
-    return if !$os_test_dirs{$OS};
-    my $need_cleanup;
-    unless (-d $os_test_dirs{$OS}) {
-	my $lib = File::Spec->catfile($os_test_dirs{$OS}, "libfoo.$Config{so}");
-	$need_cleanup = [ $lib, $os_test_dirs{$OS} ];
-	mkdir $os_test_dirs{$OS} or die "mkdir $os_test_dirs{$OS}: $!\n";
-	open my $fh, '>', $lib;
-    }
-    chdir $os_test_dirs{$OS} or die "Could not change to liblist test dir '$os_test_dirs{$OS}': $!";
-    return $need_cleanup;
-}
+    my %os_test_dirs = ( MSWin32 => 't/liblist/win32', );
+    return if !$os_test_dirs{$^O};
 
-sub cleanup_os_test_data_dir {
-    my ($cleanup) = @_;
-    my ($file, $dir) = @$cleanup;
-    unlink $file if -f $file;
-    rmdir $dir if -d $dir;
+    chdir $os_test_dirs{$^O} or die "Could not change to liblist test dir '$os_test_dirs{$^O}': $!";
+    return;
 }
 
 # Since liblist is object-based, we need to provide a mock object.
@@ -110,24 +60,14 @@ sub _ext { ExtUtils::Liblist::Kid::ext( MockEUMM->new, @_ ); }
 sub quote { join ' ', map { qq{"$_"} } @_ }
 sub double { (@_) x 2 }
 
-sub test_common {
-    my @expected = ('','','','');
-    $expected[2] = 'PerlShr/Share' if $^O eq 'VMS';
-    is_deeply( [ _ext() ], \@expected, 'empty input results in empty output' );
-    is_deeply( [ _ext( 'unreal_test' ) ], \@expected, 'non-existent file results in empty output' );
-    push @expected, [];
-    is_deeply( [ _ext( undef, 0, 1 ) ], \@expected, 'asking for real names with empty input results in an empty extra array' );
-    is_deeply( [ _ext( 'unreal_test',     0, 1 ) ], \@expected, 'asking for real names with non-existent file results in an empty extra array' );
-}
-
-sub test_kid_unix_os2 {
-    my @out = _ext( '-L. -lfoo' );
-    my $qlibre = qr/"-L[^"]+"\s+"-lfoo"/;
-    like( $out[0], $qlibre, 'existing file results in quoted extralibs' );
-    like( $out[2], $qlibre, 'existing file results in quotes ldloadlibs' );
-}
+# tests go here
 
 sub test_kid_win32 {
+
+    $Config{installarchlib} = 'lib';
+
+    is_deeply( [ _ext() ], [ ('') x 4 ], 'empty input results in empty output' );
+    is_deeply( [ _ext( 'unreal_test' ) ], [ ('') x 4 ], 'non-existent file results in empty output' );
     is_deeply( [ _ext( 'test' ) ], [ double(quote('test.lib'), '') ], 'existent file results in a path to the file. .lib is default extension with empty %Config' );
     is_deeply( [ _ext( 'c_test' ) ], [ double(quote('lib\CORE\c_test.lib'), '') ], '$Config{installarchlib}/CORE is the default search dir aside from cwd' );
     is_deeply( [ _ext( 'double' ) ], [ double(quote('double.lib'), '') ], 'once an instance of a lib is found, the search stops' );
@@ -144,6 +84,8 @@ sub test_kid_win32 {
 
     is_deeply( [ scalar _ext( 'test' ) ], [quote('test.lib')], 'asking for a scalar gives a single string' );
 
+    is_deeply( [ _ext( undef, 0, 1 ) ], [ ('') x 4, [] ], 'asking for real names with empty input results in an empty extra array' );
+    is_deeply( [ _ext( 'unreal_test',     0, 1 ) ], [ ('') x 4, [] ], 'asking for real names with non-existent file results in an empty extra array' );
     is_deeply( [ _ext( 'c_test', 0, 1 ) ], [ double(quote('lib\CORE\c_test.lib'), ''), [quote('lib/CORE\c_test.lib')] ], 'asking for real names with an existent file in search dir results in an extra array with a mixed-os file path?!' );
     is_deeply( [ _ext( 'test c_test',     0, 1 ) ], [ double(quote(qw(test.lib lib\CORE\c_test.lib)), ''), [quote('lib/CORE\c_test.lib')] ], 'files in cwd do not appear in the real name list?!' );
     is_deeply( [ _ext( '-lc_test c_test', 0, 1 ) ], [ double(quote(qw(lib\CORE\c_test.lib lib\CORE\c_test.lib)), ''), [quote('lib/CORE\c_test.lib')] ], 'finding the same lib in a search dir both with and without -l results in a single listing in the array' );


### PR DESCRIPTION
Recent work on Liblist has resulted in an endless stream of fixes and fixes upon those fixes and fixes upon fixes upon those fixes.
- The additional tests are testing garbage-in garbage out, not something useful.
- They are reporting spurious warnings to the end-users about said garbage
- I currently broken, and has been broken for other reasons before

I propose reverting to the latest state that was known to be working without issues, and not change things without discussing a bit more about what we're trying to achieve here.
