### PR TITLE
fix conflict between skip_all and END section

### DIFF
--- a/t/INSTALL_BASE.t
+++ b/t/INSTALL_BASE.t
@@ -15,12 +15,13 @@ $CLEANUP &&= 1; # so always 1 or numerically 0
 
 use MakeMaker::Test::Utils;
 use MakeMaker::Test::Setup::BFD;
-use Test::More;
 use Config;
 use ExtUtils::MM;
-plan !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
+use Test::More
+    !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
     ? (skip_all => "cross-compiling and make not available")
-    : (tests => 4 + $CLEANUP + @INSTDIRS * (15 + $CLEANUP));
+    : ();
+plan tests => 4 + $CLEANUP + @INSTDIRS * (15 + $CLEANUP);
 
 my $Is_VMS = $^O eq 'VMS';
 

--- a/t/PL_FILES.t
+++ b/t/PL_FILES.t
@@ -11,9 +11,9 @@ use File::Temp qw[tempdir];
 use MakeMaker::Test::Setup::PL_FILES;
 use MakeMaker::Test::Utils;
 use Config;
-use Test::More;
 use ExtUtils::MM;
-plan !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
+use Test::More
+    !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
     ? (skip_all => "cross-compiling and make not available")
     : (tests => 9);
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -20,9 +20,9 @@ use utf8;
 use MakeMaker::Test::Utils;
 use MakeMaker::Test::Setup::BFD;
 use Config;
-use Test::More;
 use ExtUtils::MM;
-plan !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
+use Test::More
+    !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
     ? (skip_all => "cross-compiling and make not available")
     : (tests => 171);
 use File::Find;

--- a/t/echo.t
+++ b/t/echo.t
@@ -14,11 +14,11 @@ use MakeMaker::Test::Utils;
 use File::Temp;
 use Cwd 'abs_path';
 
-use Test::More tests => 18;
 use ExtUtils::MM;
-plan !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
+use Test::More
+    !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
     ? (skip_all => "cross-compiling and make not available")
-    : ();
+    : (tests => 18);
 
 #--------------------- Setup
 

--- a/t/min_perl_version.t
+++ b/t/min_perl_version.t
@@ -13,9 +13,9 @@ use TieOut;
 use MakeMaker::Test::Utils;
 use MakeMaker::Test::Setup::MPV;
 use Config;
-use Test::More;
 use ExtUtils::MM;
-plan !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
+use Test::More
+    !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
     ? (skip_all => "cross-compiling and make not available")
     : (tests => 36);
 use File::Path;

--- a/t/pm_to_blib.t
+++ b/t/pm_to_blib.t
@@ -12,9 +12,9 @@ use ExtUtils::MakeMaker;
 use MakeMaker::Test::Utils;
 use MakeMaker::Test::Setup::BFD;
 use Config;
-use Test::More;
 use ExtUtils::MM;
-plan !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
+use Test::More
+    !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
     ? (skip_all => "cross-compiling and make not available")
     : 'no_plan';
 

--- a/t/recurs.t
+++ b/t/recurs.t
@@ -14,9 +14,9 @@ use File::Temp qw[tempdir];
 use MakeMaker::Test::Utils;
 use MakeMaker::Test::Setup::Recurs;
 use Config;
-use Test::More;
 use ExtUtils::MM;
-plan !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
+use Test::More
+    !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
     ? (skip_all => "cross-compiling and make not available")
     : (tests => 26);
 

--- a/t/several_authors.t
+++ b/t/several_authors.t
@@ -13,9 +13,9 @@ use TieOut;
 use MakeMaker::Test::Utils;
 use MakeMaker::Test::Setup::SAS;
 use Config;
-use Test::More;
 use ExtUtils::MM;
-plan !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
+use Test::More
+    !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
     ? (skip_all => "cross-compiling and make not available")
     : (tests => 20);
 use File::Path;


### PR DESCRIPTION
since the commit 430de781809a6be3bcd25a349dc40ce54405ab53
the test suite fails in cross-compil environment (perl-5.21.6 & perl-5.21.7)
like this :

```
$ ./perl harness -v ../cpan/ExtUtils-MakeMaker/t/INSTALL_BASE.t
../cpan/ExtUtils-MakeMaker/t/INSTALL_BASE.t ..
1..0 # SKIP cross-compiling and make not available
ok 1 - chdir updir
ok 2 - teardown
# Looks like you planned 0 tests but ran 2.
skipped: cross-compiling and make not available
```

this commit restores the implicit call of plan() at import time of Test::More

Signed-off-by: Francois Perrad francois.perrad@gadz.org
