### PR TITLE
Eliminate && from Makefile recipes - totally unnecessary.

### DIFF
--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -3869,7 +3869,8 @@ sub xs_c {
     return '' unless $self->needs_linking();
     '
 .xs.c:
-	$(XSUBPPRUN) $(XSPROTOARG) $(XSUBPPARGS) $(XSUBPP_EXTRA_ARGS) $*.xs > $*.xsc && $(MV) $*.xsc $*.c
+	$(XSUBPPRUN) $(XSPROTOARG) $(XSUBPPARGS) $(XSUBPP_EXTRA_ARGS) $*.xs > $*.xsc
+	$(MV) $*.xsc $*.c
 ';
 }
 
@@ -3884,7 +3885,8 @@ sub xs_cpp {
     return '' unless $self->needs_linking();
     '
 .xs.cpp:
-	$(XSUBPPRUN) $(XSPROTOARG) $(XSUBPPARGS) $*.xs > $*.xsc && $(MV) $*.xsc $*.cpp
+	$(XSUBPPRUN) $(XSPROTOARG) $(XSUBPPARGS) $*.xs > $*.xsc
+	$(MV) $*.xsc $*.cpp
 ';
 }
 

--- a/lib/ExtUtils/MM_Win95.pm
+++ b/lib/ExtUtils/MM_Win95.pm
@@ -26,57 +26,8 @@ to get MakeMaker playing nice with command.com and other Win9Xisms.
 =head2 Overridden methods
 
 Most of these make up for limitations in the Win9x/nmake command shell.
-Mostly its lack of &&.
 
 =over 4
-
-
-=item xs_c
-
-The && problem.
-
-=cut
-
-sub xs_c {
-    my($self) = shift;
-    return '' unless $self->needs_linking();
-    '
-.xs.c:
-	$(XSUBPPRUN) $(XSPROTOARG) $(XSUBPPARGS) $*.xs > $*.c
-	'
-}
-
-
-=item xs_cpp
-
-The && problem
-
-=cut
-
-sub xs_cpp {
-    my($self) = shift;
-    return '' unless $self->needs_linking();
-    '
-.xs.cpp:
-	$(XSUBPPRUN) $(XSPROTOARG) $(XSUBPPARGS) $*.xs > $*.cpp
-	';
-}
-
-=item xs_o
-
-The && problem.
-
-=cut
-
-sub xs_o {
-    my($self) = shift;
-    return '' unless $self->needs_linking();
-    '
-.xs$(OBJ_EXT):
-	$(XSUBPPRUN) $(XSPROTOARG) $(XSUBPPARGS) $*.xs > $*.c
-	$(CCCMD) $(CCCDLFLAGS) -I$(PERL_INC) $(DEFINE) $*.c
-	';
-}
 
 
 =item max_exec_len


### PR DESCRIPTION
Justification: increases recipes' portability, notably on Win95.

Split out from #176, since @bulk88 disagrees: https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/pull/168#issuecomment-67590474 and https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/pull/176#issuecomment-67891163.