### PR TITLE
Fixes for 5.6.1 compatibility

### DIFF
--- a/lib/ExtUtils/MakeMaker/version.pm
+++ b/lib/ExtUtils/MakeMaker/version.pm
@@ -10,7 +10,7 @@
 
 package ExtUtils::MakeMaker::version;
 
-use 5.006002;
+use 5.006001;
 use strict;
 
 use vars qw(@ISA $VERSION $CLASS $STRICT $LAX *declare *qv);

--- a/lib/ExtUtils/MakeMaker/version/vpp.pm
+++ b/lib/ExtUtils/MakeMaker/version/vpp.pm
@@ -123,7 +123,7 @@ sub currstr {
 
 package ExtUtils::MakeMaker::version::vpp;
 
-use 5.006002;
+use 5.006001;
 use strict;
 
 use Config;

--- a/t/lib/MakeMaker/Test/Utils.pm
+++ b/t/lib/MakeMaker/Test/Utils.pm
@@ -429,7 +429,7 @@ Returns the return value of the given code.
 sub in_dir(&;$) {
     my $code = shift;
     require File::Temp;
-    my $dir = shift || File::Temp->newdir;
+    my $dir = shift || File::Temp::tempdir(TMPDIR => 1, CLEANUP => 1);
     # chdir to the new directory
     my $orig_dir = getcwd();
     chdir $dir or die "Can't chdir to $dir: $!";

--- a/t/meta_convert.t
+++ b/t/meta_convert.t
@@ -4,9 +4,8 @@ use strict;
 use warnings;
 
 BEGIN { unshift @INC, 't/lib'; }
-use Test::More;
-eval { require CPAN::Meta; };
-plan skip_all => 'Failed to load CPAN::Meta' if $@;
+use Test::More eval { require CPAN::Meta; } ? ()
+  : (skip_all => 'Failed to load CPAN::Meta');
 use File::Temp qw[tempdir];
 require ExtUtils::MM_Any;
 

--- a/t/metafile_data.t
+++ b/t/metafile_data.t
@@ -358,6 +358,7 @@ SKIP: {
     skip 'Loading Parse::CPAN::Meta failed', 5 unless $PCM;
     my $meta = $mm->mymeta("t/META_for_testing_tricky_version.yml");
     is $meta->{'meta-spec'}{version}, 2, "internally, our MYMETA struct is v2";
+    skip 'Loading CPAN::Meta failed', 4 unless $CM;
     in_dir {
         $mm->write_mymeta($meta);
         ok -e "MYMETA.yml";
@@ -372,6 +373,7 @@ SKIP: {
 note "A bad license string";
 SKIP: {
     skip 'Loading Parse::CPAN::Meta failed', 2 unless $PCM;
+    skip 'Loading CPAN::Meta failed', 2 unless $CM;
     my $mm = $new_mm->(
         @GENERIC_IN,
         LICENSE   => 'death and retribution',


### PR DESCRIPTION
This fixes some tests to be more compatible with missing or old modules, as well as relaxing the version requirement in ExtUtils::MakeMaker::version to 5.6.1.  All tests pass.