### PR TITLE
do proper conversion to 2.x for META_ADD/MERGE

### DIFF
--- a/t/metafile_data.t
+++ b/t/metafile_data.t
@@ -112,10 +112,10 @@ my @GENERIC_OUT = (
         },
         no_index        => {
             directory           => [qw(t inc)],
-            package             => 'Thing',
+            package             => ['Thing'],
         },
-        wibble  => 23,
-        wobble  => 42,
+        x_wibble  => 23,
+        x_wobble  => 42,
     }, '_add vs _merge';
 }
 

--- a/t/metafile_data.t
+++ b/t/metafile_data.t
@@ -3,15 +3,22 @@ BEGIN {
 }
 
 use strict;
-use Test::More tests => 31;
+use Test::More;
+BEGIN {
+  eval { require CPAN::Meta; }
+    or plan skip_all => 'CPAN::Meta required for this test';
+  eval { require CPAN::Meta::Converter; }
+    or plan skip_all => 'CPAN::Meta::Converter required for this test';
+  eval { require Parse::CPAN::Meta; }
+    or plan skip_all => 'Parse::CPAN::Meta required for this test';
+}
 use Data::Dumper;
 use File::Temp;
 use Cwd;
 use MakeMaker::Test::Utils;
 
+plan tests => 31;
 require ExtUtils::MM_Any;
-my $PCM = eval { require Parse::CPAN::Meta; };
-my $CM = eval { require CPAN::Meta; };
 
 sub mymeta_ok {
     my($have, $want, $name) = @_;
@@ -256,7 +263,7 @@ my @GENERIC_OUT = (
 }
 
 # Test _REQUIRES key priority over META_ADD
-SKIP: {
+{
     my $mm = $new_mm->(
         @GENERIC_IN,
         BUILD_REQUIRES => { "Fake::Module1" => 1.01, },
@@ -270,8 +277,7 @@ SKIP: {
         @GENERIC_OUT,
     },'META.yml data (META_ADD wins)';
     # Yes, this is all hard coded.
-    skip 'Loading CPAN::Meta failed', 6 unless $CM;
-    require CPAN::Meta;
+
     my $want_mymeta = {
         name            => 'ExtUtils-MakeMaker',
         version         => '6.57_07',
@@ -315,14 +321,13 @@ SKIP: {
               'MYMETA YAML data (BUILD_REQUIRES wins)';
 }
 
-SKIP: {
+{
     my $mm = $new_mm->(
         @GENERIC_IN,
         CONFIGURE_REQUIRES  => { "Fake::Module0" => 0.99 },
         BUILD_REQUIRES      => { "Fake::Module1" => 1.01 },
         TEST_REQUIRES       => { "Fake::Module2" => 1.23 },
     );
-    skip 'Loading CPAN::Meta failed', 5 unless $CM;
     my $meta = $mm->mymeta('t/META_for_testing.json');
     is($meta->{configure_requires}, undef, "no configure_requires in v2 META");
     is($meta->{build_requires}, undef, "no build_requires in v2 META");
@@ -344,7 +349,7 @@ SKIP: {
 }
 
 note "CPAN::Meta bug using the module version instead of the meta spec version";
-SKIP: {
+{
     my $mm = $new_mm->(
         NAME      => 'GD::Barcode::Code93',
         AUTHOR    => 'Chris DiMartino',
@@ -355,10 +360,8 @@ SKIP: {
         },
         VERSION   => '1.4',
     );
-    skip 'Loading Parse::CPAN::Meta failed', 5 unless $PCM;
     my $meta = $mm->mymeta("t/META_for_testing_tricky_version.yml");
     is $meta->{'meta-spec'}{version}, 2, "internally, our MYMETA struct is v2";
-    skip 'Loading CPAN::Meta failed', 4 unless $CM;
     in_dir {
         $mm->write_mymeta($meta);
         ok -e "MYMETA.yml";
@@ -371,9 +374,7 @@ SKIP: {
 }
 
 note "A bad license string";
-SKIP: {
-    skip 'Loading Parse::CPAN::Meta failed', 2 unless $PCM;
-    skip 'Loading CPAN::Meta failed', 2 unless $CM;
+{
     my $mm = $new_mm->(
         @GENERIC_IN,
         LICENSE   => 'death and retribution',


### PR DESCRIPTION
Use CPAN::Meta::Converter to convert to 2.x instead of failing to
reimplement it.  Specifically, this fixes converting resources.
Requiring CPAN::Meta for this bit isn't a problem because everything
using the metafile_data method already requires it.

Passing everything through CPAN::Meta::Converter has the side effect of
cloning all of the structures.  This means we no longer modify the items
in META_ADD when running metafile_data, so running in multiple times
won't cause problems.