### PR TITLE
add pure_all and subdirs to PHONY

### DIFF
--- a/lib/ExtUtils/MM_Any.pm
+++ b/lib/ExtUtils/MM_Any.pm
@@ -1855,7 +1855,7 @@ sub special_targets {
     my $make_frag = <<'MAKE_FRAG';
 .SUFFIXES : .xs .c .C .cpp .i .s .cxx .cc $(OBJ_EXT)
 
-.PHONY: all config static dynamic test linkext manifest blibdirs clean realclean disttest distdir
+.PHONY: all config static dynamic test linkext manifest blibdirs clean realclean disttest distdir pure_all subdirs
 
 MAKE_FRAG
 


### PR DESCRIPTION
these 2 targets will never be found on disk, by putting them in PHONY the
make tool (dmake in my case) won't do disk IO to check if they exist after
"building" them, which make things slightly faster. I did see dmake
on Win32 checking the disk for these 2 files with ProcMon and dmake
stopped checking the disk for these 2 files after being added to PHONY.