### PR TITLE
Travis silently switches to newer perl on some tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,27 +7,16 @@ notifications:
 sudo: false
 perl:
   - "blead"
-  - "5.6.2"
-  - "5.8.1"
-  - "5.8.5"
-  - "5.8.7"
-  - "5.8.8"
-  - "5.8.9"
-  - "5.10.0"
-  - "5.10.1"
-  - "5.12.0"
+  - "5.8"
+  - "5.10"
   - "5.12"
-  - "5.14.0"
   - "5.14"
-  - "5.16.0"
   - "5.16"
-  - "5.18.0"
   - "5.18"
   - "5.20"
 matrix:
   allow_failures:
     - perl: "blead"
-    - perl: "5.6.2"
 before_install:
   - git clone git://github.com/haarg/perl-travis-helper ~/perl-travis-helper
   - source ~/perl-travis-helper/init


### PR DESCRIPTION
If Travis encounters a Perl version that does not exist, it falls back to a newer version, eg: https://travis-ci.org/Perl-Toolchain-Gang/ExtUtils-MakeMaker/jobs/52743876

    $ perlbrew use 5.8.1
    ERROR: The installation "5.8.1" is unknown.
    $ perl --version
    This is perl 5, version 14, subversion 2 (v5.14.2) built for x86_64-linux-gnu-thread-multi
    (with 57 registered patches, see perl -V for more detail)

This holds true for all three digit versions and for all 5.6 versions.

Such behaviour leads to tests that pass but don't actually run on the intended platform. Thus they provide false information. Therefore this patch removes the offending entries.