### PR TITLE
for dmake use makefile.mk instead of Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *~
 *.old
 Makefile
+makefile.mk
 blib/
 pm_to_blib
 Build

--- a/lib/ExtUtils/MM_Win32.pm
+++ b/lib/ExtUtils/MM_Win32.pm
@@ -141,6 +141,9 @@ sub init_tools {
 
     $self->{NOOP}     ||= 'rem';
     $self->{DEV_NULL} ||= '> NUL';
+    $self->{FIRST_MAKEFILE} ||=
+	$self->{MAKEFILE}
+	|| ($self->is_make_type('dmake') ? 'makefile.mk' : 'Makefile');
 
     $self->{FIXIN}    ||= $self->{PERL_CORE} ?
       "\$(PERLRUN) $self->{PERL_SRC}\\win32\\bin\\pl2bat.pl" :

--- a/t/lib/MakeMaker/Test/Utils.pm
+++ b/t/lib/MakeMaker/Test/Utils.pm
@@ -195,7 +195,7 @@ should generate.
 =cut
 
 sub makefile_name {
-    return $Is_VMS ? 'Descrip.MMS' : 'Makefile';
+    return $Is_VMS ? 'Descrip.MMS' : (make() =~ /\bdmake\b/) ? 'makefile.mk' : 'Makefile';
 }
 
 =item B<makefile_backup>


### PR DESCRIPTION
This is an idea from my recent work at optimizing dmake. It also allows 2 makefiles, one for VC (almost always nmake, very rarely dmake) Perl, and one for Strawberry (always dmake) perl to coexist in the same directory.