### PR TITLE
Fix Cygwin rebase command by adding pipe

### DIFF
--- a/lib/ExtUtils/MM_Cygwin.pm
+++ b/lib/ExtUtils/MM_Cygwin.pm
@@ -154,7 +154,7 @@ sub install {
     my $INSTALLLIB = $self->{"INSTALL". ($INSTALLDIRS eq 'perl' ? 'ARCHLIB' : uc($INSTALLDIRS)."ARCH")};
     my $dop = "\$\(DESTDIR\)$INSTALLLIB/auto/";
     my $dll = "$dop/$self->{FULLEXT}/$self->{BASEEXT}.$self->{DLEXT}";
-    $s =~ s|^(pure_install :: pure_\$\(INSTALLDIRS\)_install\n\t)\$\(NOECHO\) \$\(NOOP\)\n|$1\$(CHMOD) \$(PERM_RWX) $dll\n\t/bin/find $dop -xdev -name \\*.$self->{DLEXT} /bin/rebase -sOT -\n|m if (( $Config{myarchname} eq 'i686-cygwin') and not ( exists $ENV{CYGPORT_PACKAGE_VERSION} ));
+    $s =~ s|^(pure_install :: pure_\$\(INSTALLDIRS\)_install\n\t)\$\(NOECHO\) \$\(NOOP\)\n|$1\$(CHMOD) \$(PERM_RWX) $dll\n\t/bin/find $dop -xdev -name \\*.$self->{DLEXT} \| /bin/rebase -sOT -\n|m if (( $Config{myarchname} eq 'i686-cygwin') and not ( exists $ENV{CYGPORT_PACKAGE_VERSION} ));
     $s;
 }
 


### PR DESCRIPTION
Commit 037a0a1d introduced automatic rebasing for Cygwin, but inadvertently left out a pipe character in the necessary command, causing compilations to fail with errors like:

```
/bin/find /usr/lib/perl5/site_perl/5.14/i686-cygwin-threads-64int/auto/ -xdev -name \*.dll /bin/rebase -sOT -
/bin/find: paths must precede expression: /bin/rebase
Usage: /bin/find [-H] [-L] [-P] [-Olevel] [-D help|tree|search|stat|rates|opt|exec] [path...] [expression]
Makefile:719: recipe for target 'pure_install' failed
make: *** [pure_install] Error 1
```

This pull request adds the missing pipe character. Please note that I have not directly tested this fix; I have only indirectly tested it by adding the pipe character to one of the generated Makefiles, allowing the module in question to report a successful installation. This will need review and testing to make sure this fix is correct.