### PR TITLE
Remove pure_nolink change

### DIFF
--- a/lib/ExtUtils/MM_Any.pm
+++ b/lib/ExtUtils/MM_Any.pm
@@ -1036,11 +1036,7 @@ sub dynamic {
 
     my($self) = shift;
     '
-dynamic :: $(FIRST_MAKEFILE) $(INST_BOOT) $(INST_DYNAMIC) subdirs_dynamic
-	$(NOECHO) $(NOOP)
-
-# define this here not top_targets in case someone overrides that
-subdirs_dynamic :: pure_nolink
+dynamic :: $(FIRST_MAKEFILE) $(INST_BOOT) $(INST_DYNAMIC)
 	$(NOECHO) $(NOOP)
 ';
 }
@@ -1087,18 +1083,10 @@ sub manifypods_target {
         $dependencies .= " \\\n\t$name";
     }
 
-    my @m;
-    push @m, <<END;
-
-subdirs_manifypods :: subdirs_pure_nolink config $dependencies
+    my $manify = <<END;
+manifypods : pure_all config $dependencies
 END
-    foreach my $dir (@{$self->{DIR}}){
-        push @m, $self->subdir_x($dir, 'manifypods');
-    }
-    push @m, <<END;
 
-manifypods : subdirs_manifypods
-END
     my @man_cmds;
     foreach my $section (qw(1 3)) {
         my $pods = $self->{"MAN${section}PODS"};
@@ -1108,10 +1096,10 @@ CMD
         push @man_cmds, $self->split_command($p2m, map {($_,$pods->{$_})} sort keys %$pods);
     }
 
-    push @m, "\t\$(NOECHO) \$(NOOP)\n" unless @man_cmds;
-    push @m, map { "$_\n" } @man_cmds;
+    $manify .= "\t\$(NOECHO) \$(NOOP)\n" unless @man_cmds;
+    $manify .= join '', map { "$_\n" } @man_cmds;
 
-    return join '', @m;
+    return $manify;
 }
 
 sub _has_cpan_meta {

--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -3641,7 +3641,7 @@ test_ : test_$default_testtype
 EOF
 
     for my $linktype (qw(dynamic static)) {
-        push @m, "subdirs-test_$linktype :: $linktype\n";
+        push @m, "subdirs-test_$linktype :: $linktype pure_all\n";
         foreach my $dir (@{ $self->{DIR} }) {
             my $test = $self->cd($dir, "\$(MAKE) test_$linktype \$(PASTHRU)");
             push @m, "\t\$(NOECHO) $test\n";

--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -2356,7 +2356,7 @@ sub installbin {
     push(@m, qq{
 EXE_FILES = @exefiles
 
-pure_nolink :: @to
+pure_all :: @to
 	\$(NOECHO) \$(NOOP)
 
 realclean ::
@@ -2393,18 +2393,14 @@ Defines the linkext target which in turn defines the LINKTYPE.
 # LINKTYPE => static or dynamic or ''
 sub linkext {
     my($self, %attribs) = @_;
-    my $extra = ''; # so if LINKTYPE eq '' and there are DIR
-                    # we can bring in subdirs_(perl-linktype) for back-compat
     my $linktype = $attribs{LINKTYPE};
     $linktype = $self->{LINKTYPE} unless defined $linktype;
     if (defined $linktype and $linktype eq '') {
-        # bring in subdirs even if none exist as brings in pure_nolink
         warn "Warning: LINKTYPE set to '', no longer necessary\n";
-        $extra = 'subdirs_' . ($Config{usedl} ? 'dynamic' : 'static');
     }
     $linktype = '$(LINKTYPE)' unless defined $linktype;
     "
-linkext :: $linktype $extra
+linkext :: $linktype
 	\$(NOECHO) \$(NOOP)
 ";
 }
@@ -3245,7 +3241,7 @@ sub processPL {
 
             $m .= <<MAKE_FRAG;
 
-pure_nolink :: $target
+all :: $target
 	\$(NOECHO) \$(NOOP)
 
 $target :: $plfile $pm_dep
@@ -3414,11 +3410,7 @@ sub static {
     '
 ## $(INST_PM) has been moved to the all: target.
 ## It remains here for awhile to allow for old usage: "make static"
-static :: $(FIRST_MAKEFILE) $(INST_STATIC) subdirs_static
-	$(NOECHO) $(NOOP)
-
-# define this here not top_targets in case someone overrides that
-subdirs_static :: pure_nolink
+static :: $(FIRST_MAKEFILE) $(INST_STATIC)
 	$(NOECHO) $(NOOP)
 ';
 }
@@ -3566,14 +3558,14 @@ Helper subroutine for subdirs
 =cut
 
 sub subdir_x {
-    my($self, $subdir, $target) = @_;
+    my($self, $subdir) = @_;
 
     my $subdir_cmd = $self->cd($subdir,
-      sprintf '$(MAKE) $(USEMAKEFILE) $(FIRST_MAKEFILE) %s $(PASTHRU)', $target
+      '$(MAKE) $(USEMAKEFILE) $(FIRST_MAKEFILE) all $(PASTHRU)'
     );
-    return sprintf <<'EOT', "subdirs_$target", $subdir_cmd;
+    return sprintf <<'EOT', $subdir_cmd;
 
-%s ::
+subdirs ::
 	$(NOECHO) %s
 EOT
 
@@ -3593,7 +3585,7 @@ sub subdirs {
     # subdirectories containing further Makefile.PL scripts.
     # It calls the subdir_x() method for each subdirectory.
     foreach my $dir (@{$self->{DIR}}){
-	push @m, map $self->subdir_x($dir, $_), qw(pure_nolink static dynamic);
+	push @m, $self->subdir_x($dir);
 ####	print "Including $dir subdirectory\n";
     }
     if (@m){
@@ -3819,37 +3811,15 @@ sub top_targets {
     push @m, $self->all_target, "\n" unless $self->{SKIPHASH}{'all'};
 
     push @m, sprintf <<'EOF', $Config{usedl} ? 'dynamic' : 'static';
-pure_all :: linkext
+pure_all :: config pm_to_blib subdirs linkext
 	$(NOECHO) $(NOOP)
 
-pure_nolink :: config pm_to_blib subdirs_pure_nolink
 	$(NOECHO) $(NOOP)
 
-# this is in case of overrides, no longer used by EUMM natively
-subdirs :: subdirs_$(LINKTYPE)
-	$(NOECHO) $(NOOP)
-
-# in case LINKTYPE not set
-subdirs_ :: subdirs_%s
-	$(NOECHO) $(NOOP)
-
-subdirs_pure_nolink ::
-	$(NOECHO) $(NOOP)
-
-subdirs_dynamic :: $(MYEXTLIB)
-	$(NOECHO) $(NOOP)
-
-subdirs_static :: $(MYEXTLIB)
+subdirs :: $(MYEXTLIB)
 	$(NOECHO) $(NOOP)
 
 config :: $(FIRST_MAKEFILE) blibdirs
-	$(NOECHO) $(NOOP)
-
-# back-compat in case of override of static or dynamic
-static :: pure_nolink
-	$(NOECHO) $(NOOP)
-
-dynamic :: pure_nolink
 	$(NOECHO) $(NOOP)
 EOF
 

--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -3810,7 +3810,7 @@ sub top_targets {
 
     push @m, $self->all_target, "\n" unless $self->{SKIPHASH}{'all'};
 
-    push @m, sprintf <<'EOF', $Config{usedl} ? 'dynamic' : 'static';
+    push @m, sprintf <<'EOF';
 pure_all :: config pm_to_blib subdirs linkext
 	$(NOECHO) $(NOOP)
 

--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -841,7 +841,7 @@ all :
 
 manifypods :
 
-pure_nolink :
+subdirs :
 
 dynamic :
 
@@ -1346,11 +1346,16 @@ sub selfdocument {
     push @m, <<'EOF';
 
 # here so even if top_targets is overridden, these will still be defined
-# gmake will silently not fail if any are .PHONY-ed but nmake won't
+# gmake will silently still work if any are .PHONY-ed but nmake won't
+static ::
+	$(NOECHO) $(NOOP)
+
+dynamic ::
+	$(NOECHO) $(NOOP)
 EOF
     push @m, join "\n", map "$_ ::\n\t\$(NOECHO) \$(NOOP)\n",
-        # last two are so manifypods won't puke if no subdirs
-        qw(pure_nolink static dynamic subdirs_pure_nolink config);
+        # config is so manifypods won't puke if no subdirs
+        qw(static dynamic config);
     join "\n", @m;
 }
 

--- a/t/unicode.t
+++ b/t/unicode.t
@@ -108,8 +108,8 @@ if ($] >= 5.008) {
 }
 
 my $make = make_run();
-my $make_out = run("$make");
-is $? >> 8, 0, 'Exit code of make == 0';
+my $make_out = run($make);
+diag $make_out unless is $? >> 8, 0, 'Exit code of make == 0';
 
 my $manfile = File::Spec->catfile(qw(blib man1 probscript.1));
 SKIP: {
@@ -128,7 +128,7 @@ SKIP: {
 }
 
 $make_out = run("$make realclean");
-is $? >> 8, 0, 'Exit code of make == 0';
+diag $make_out unless is $? >> 8, 0, 'Exit code of make == 0';
 
 sub makefile_content {
   open my $fh, '<', makefile_name or die;


### PR DESCRIPTION
Under GNU make 3.8* and 4.1, perl build fails with -j4. With the pure_nolink (etc) change reverted, it succeeds again. Passes tests on Linux and Win32 "in space".

PR-ing for visibility.