### PR TITLE
Use same build-info dir as Module::Build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ MYMETA.*
 ExtUtils-MakeMaker-*
 inc/
 .*.swp
-/_eumm
+/_build

--- a/bundled/ExtUtils-Manifest/ExtUtils/MANIFEST.SKIP
+++ b/bundled/ExtUtils-Manifest/ExtUtils/MANIFEST.SKIP
@@ -22,7 +22,7 @@
 \bpm_to_blib\.ts$
 \bpm_to_blib$
 \bblibdirs\.ts$         # 6.18 through 6.25 generated this
-\b_eumm/                # 7.05_05 and above
+\b_build/               # 7.08_01 and above
 
 # Avoid Module::Build generated and utility files.
 \bBuild$

--- a/lib/ExtUtils/MM_Any.pm
+++ b/lib/ExtUtils/MM_Any.pm
@@ -23,7 +23,7 @@ my $Updir   = __PACKAGE__->updir;
 
 my $METASPEC_URL = 'https://metacpan.org/pod/CPAN::Meta::Spec';
 my $METASPEC_V = 2;
-my $STASHDIR = File::Spec->catdir('blib', '_eumm');
+my $STASHDIR = '_build';
 
 =head1 NAME
 
@@ -725,7 +725,7 @@ clean :: clean_subdirs
 	my $file = $_;
 	map { $file.$_ } $self->{OBJ_EXT}, qw(.def _def.old .bs .bso .exp .base);
     } $self->_xs_list_basenames;
-    my @dirs  = qw(blib _eumm);
+    my @dirs  = qw(_build);
 
     # Normally these are all under blib but they might have been
     # redefined.

--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -842,7 +842,7 @@ sub WriteEmptyMakefile {
     my $self = MM->new(\%att);
     require File::Path;
     require File::Spec;
-    File::Path::rmtree( File::Spec->catdir(qw[blib _eumm]) ); # because MM->new does too much stuff
+    File::Path::rmtree( File::Spec->catdir(qw[_build]) ); # because MM->new does too much stuff
 
     my $new = $self->{MAKEFILE};
     my $old = $self->{MAKEFILE_OLD};

--- a/t/WriteEmptyMakefile.t
+++ b/t/WriteEmptyMakefile.t
@@ -33,5 +33,5 @@ like $@, qr/Need an even number of args/, 'correct exception';
         FIRST_MAKEFILE  => "wibble",
     );
     ok -e 'wibble', 'yes wibble';
-    ok !-d 'blib/_eumm', 'no _eumm lying around';
+    ok !-d '_build', 'no _build lying around';
 }

--- a/t/basic.t
+++ b/t/basic.t
@@ -179,7 +179,7 @@ sub check_dummy_inst {
     ok( $files{'program'},      '  program installed'  );
     ok( $files{'.packlist'},    '  packlist created'   );
     ok( $files{'perllocal.pod'},'  perllocal.pod created' );
-    ok( !$files{'_eumm'},        '  should not be an _eumm' );
+    ok( !$files{'_build'},      '  should not be an _build' );
     \%files;
 }
 

--- a/t/lib/MakeMaker/Test/Setup/XS.pm
+++ b/t/lib/MakeMaker/Test/Setup/XS.pm
@@ -15,7 +15,7 @@ use File::Spec;
 use File::Temp qw[tempdir];
 use Cwd;
 use ExtUtils::MM;
-# this is to avoid MM->new overwriting _eumm in top dir
+# this is to avoid MM->new overwriting _build in top dir
 my $tempdir = tempdir(DIR => getcwd, CLEANUP => 1);
 chdir $tempdir;
 my $typemap = 'type map';

--- a/t/meta_convert.t
+++ b/t/meta_convert.t
@@ -13,7 +13,7 @@ my $tmpdir = tempdir( DIR => 't', CLEANUP => 1 );
 use Cwd; my $cwd = getcwd; END { chdir $cwd } # so File::Temp can cleanup
 chdir $tmpdir or die "chdir $tmpdir: $!";
 
-my $METAJSON = File::Spec->catfile('blib', '_eumm', 'META_new.json');
+my $METAJSON = File::Spec->catfile('_build', 'META_new.json');
 my $EMPTY = qr/['"]?version['"]?\s*:\s*['"]['"]/;
 my @DATA = (
     [


### PR DESCRIPTION
So far as I know, this does not clash with Module::Build or any other toolchain module. I await constructive feedback.

This will address https://rt.cpan.org/Ticket/Display.html?id=106927

cf #235 