### PR TITLE
- stop makeaperl from polluting @ARGV in cases where ARGV contains ar…

### DIFF
--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -2483,8 +2483,8 @@ $(MAKE_APERL_FILE) : static $(FIRST_MAKEFILE) pm_to_blib
 
 	foreach (@ARGV){
 		my $arg = $_; # avoid lvalue aliasing
-		if ( $arg =~ /\s/ ) {
-			$arg =~ s/=(.*)/='$1'/;
+		if ( $arg =~ /(^.*?=)(.*['\s].*)/ ) {
+			$arg = $1 . $self->quote_literal($2);
 		}
 		push @m, " \\\n\t\t$arg";
 	}

--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -2482,12 +2482,12 @@ $(MAKE_APERL_FILE) : static $(FIRST_MAKEFILE) pm_to_blib
 		MAKEAPERL=1 NORECURS=1 CCCDLFLAGS=};
 
 	foreach (@ARGV){
-		if( /\s/ ){
-			s/=(.*)/='$1'/;
+		my $arg = $_; # avoid lvalue aliasing
+		if ( $arg =~ /\s/ ) {
+			$arg =~ s/=(.*)/='$1'/;
 		}
-		push @m, " \\\n\t\t$_";
+		push @m, " \\\n\t\t$arg";
 	}
-#	push @m, map( " \\\n\t\t$_", @ARGV );
 	push @m, "\n";
 
 	return join '', @m;

--- a/t/MM_Unix.t
+++ b/t/MM_Unix.t
@@ -223,7 +223,7 @@ foreach (qw/ EXPORT_LIST PERL_ARCHIVE PERL_ARCHIVE_AFTER /)
 }
 
 {
-    my @targv = ("var=val with spaces");
+    my @targv = ("var=don't forget about spaces and single quotes");
     local @ARGV = @targv;
     my $t = bless { NAME => "Foo", FULLPERL => $0, DIR => [] }, $class;
     $t->makeaperl( TARGET => "Tgt" );

--- a/t/MM_Unix.t
+++ b/t/MM_Unix.t
@@ -222,13 +222,10 @@ foreach (qw/ EXPORT_LIST PERL_ARCHIVE PERL_ARCHIVE_AFTER /)
     like( $t->{CCFLAGS}, qr/\-DMY_THING/,    'cflags retains CCFLAGS' );
 }
 
-#
 {
-    my @orig = @ARGV;
     my @targv = ("var=val with spaces");
-    @ARGV = @targv;
+    local @ARGV = @targv;
     my $t = bless { NAME => "Foo", FULLPERL => $0, DIR => [] }, $class;
     $t->makeaperl( TARGET => "Tgt" );
     is_deeply( \@ARGV, \@targv, 'ARGV is not polluted by makeaperl' );
-    @ARGV = @orig;
 }

--- a/t/MM_Unix.t
+++ b/t/MM_Unix.t
@@ -12,7 +12,7 @@ BEGIN {
         plan skip_all => 'Non-Unix platform';
     }
     else {
-        plan tests => 109;
+        plan tests => 110;
     }
 }
 
@@ -222,3 +222,13 @@ foreach (qw/ EXPORT_LIST PERL_ARCHIVE PERL_ARCHIVE_AFTER /)
     like( $t->{CCFLAGS}, qr/\-DMY_THING/,    'cflags retains CCFLAGS' );
 }
 
+#
+{
+    my @orig = @ARGV;
+    my @targv = ("var=val with spaces");
+    @ARGV = @targv;
+    my $t = bless { NAME => "Foo", FULLPERL => $0, DIR => [] }, $class;
+    $t->makeaperl( TARGET => "Tgt" );
+    is_deeply( \@ARGV, \@targv, 'ARGV is not polluted by makeaperl' );
+    @ARGV = @orig;
+}


### PR DESCRIPTION
…gs with spaces (ex: perl Makefile.PL LIBS='-L... -l...')

Background:
I ran into this issue when building Net::SSLeay and found that it ends up running through MakeMaker twice via inc::Module::Install code and on the second pass through @ARGV was polluted (extra single quotes wrapping args with spaces (LIBS in my case since we have a custom build of OpenSSL in a custom location/run path).