### PR TITLE
dont repeatedly require CPAN::Meta; if not available

### DIFF
--- a/lib/ExtUtils/MM_Any.pm
+++ b/lib/ExtUtils/MM_Any.pm
@@ -1102,12 +1102,16 @@ CMD
     return $manify;
 }
 
-sub _has_cpan_meta {
-    return eval {
-      require CPAN::Meta;
-      CPAN::Meta->VERSION(2.112150);
-      1;
-    };
+{
+    my $has_cpan_meta;
+    sub _has_cpan_meta {
+        return $has_cpan_meta if defined $has_cpan_meta;
+        return $has_cpan_meta = !!eval {
+            require CPAN::Meta;
+            CPAN::Meta->VERSION(2.112150);
+            1;
+        };
+    }
 }
 
 =head3 metafile_target


### PR DESCRIPTION
During the dmake Win32 parallel build, CPAN::Meta is unavailable since it
was not built yet, do not require it over and over if it isn't available.
This saves disk IO.