### PR TITLE
Remove _eumm dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ MYMETA.*
 ExtUtils-MakeMaker-*
 inc/
 .*.swp
-/_eumm

--- a/lib/ExtUtils/MM_Any.pm
+++ b/lib/ExtUtils/MM_Any.pm
@@ -23,7 +23,7 @@ my $Updir   = __PACKAGE__->updir;
 
 my $METASPEC_URL = 'https://metacpan.org/pod/CPAN::Meta::Spec';
 my $METASPEC_V = 2;
-my $STASHDIR = File::Spec->catdir('blib', '_eumm');
+my $STASHDIR = '_eumm';
 
 =head1 NAME
 
@@ -376,8 +376,7 @@ at build-time.
 
 sub stashmeta {
     my($self, $text, $file) = @_;
-    require File::Path;
-    -d $STASHDIR or die "$STASHDIR: $!" unless File::Path::mkpath($STASHDIR,0,0777);
+    -d $STASHDIR or die "$STASHDIR: $!" unless mkdir $STASHDIR;
     my $stashfile = File::Spec->catfile($STASHDIR, $file);
     write_file_via_tmp($stashfile, [ $text ]);
     my $qlfile = $self->quote_literal($file);

--- a/lib/ExtUtils/MM_Any.pm
+++ b/lib/ExtUtils/MM_Any.pm
@@ -10,7 +10,7 @@ use File::Basename;
 BEGIN { our @ISA = qw(File::Spec); }
 
 # We need $Verbose
-use ExtUtils::MakeMaker qw($Verbose write_file_via_tmp neatvalue _sprintf562);
+use ExtUtils::MakeMaker qw($Verbose neatvalue _sprintf562);
 
 use ExtUtils::MakeMaker::Config;
 
@@ -23,7 +23,6 @@ my $Updir   = __PACKAGE__->updir;
 
 my $METASPEC_URL = 'https://metacpan.org/pod/CPAN::Meta::Spec';
 my $METASPEC_V = 2;
-my $STASHDIR = '_eumm';
 
 =head1 NAME
 
@@ -376,15 +375,7 @@ at build-time.
 
 sub stashmeta {
     my($self, $text, $file) = @_;
-    -d $STASHDIR or die "$STASHDIR: $!" unless mkdir $STASHDIR;
-    my $stashfile = File::Spec->catfile($STASHDIR, $file);
-    write_file_via_tmp($stashfile, [ $text ]);
-    my $qlfile = $self->quote_literal($file);
-    my $qlstashfile = $self->quote_literal($stashfile);
-    (
-        sprintf('-$(NOECHO) $(RM_F) %s', $qlfile),
-        sprintf('-$(NOECHO) $(CP) %s %s', $qlstashfile, $qlfile),
-    );
+    $self->echo($text, $file, { allow_variables => 0, append => 0 });
 }
 
 
@@ -724,7 +715,7 @@ clean :: clean_subdirs
 	my $file = $_;
 	map { $file.$_ } $self->{OBJ_EXT}, qw(.def _def.old .bs .bso .exp .base);
     } $self->_xs_list_basenames;
-    my @dirs  = qw(blib _eumm);
+    my @dirs  = qw(blib);
 
     # Normally these are all under blib but they might have been
     # redefined.

--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -841,8 +841,7 @@ sub WriteEmptyMakefile {
     $att{DIR} = [] unless $att{DIR}; # don't recurse by default
     my $self = MM->new(\%att);
     require File::Path;
-    require File::Spec;
-    File::Path::rmtree( File::Spec->catdir(qw[blib _eumm]) ); # because MM->new does too much stuff
+    File::Path::rmtree '_eumm'; # because MM->new does too much stuff
 
     my $new = $self->{MAKEFILE};
     my $old = $self->{MAKEFILE_OLD};

--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -837,11 +837,8 @@ sub WriteEmptyMakefile {
     croak "WriteEmptyMakefile: Need an even number of args" if @_ % 2;
 
     my %att = @_;
-    $att{NAME} = 'Dummy' unless $att{NAME}; # eliminate pointless warnings
     $att{DIR} = [] unless $att{DIR}; # don't recurse by default
     my $self = MM->new(\%att);
-    require File::Path;
-    File::Path::rmtree '_eumm'; # because MM->new does too much stuff
 
     my $new = $self->{MAKEFILE};
     my $old = $self->{MAKEFILE_OLD};
@@ -852,7 +849,7 @@ sub WriteEmptyMakefile {
         _rename($new, $old) or warn "rename $new => $old: $!"
     }
     open my $mfh, '>', $new or die "open $new for write: $!";
-    printf $mfh <<'EOP', $self->{RM_F}, $self->{MAKEFILE};
+    print $mfh <<'EOP';
 all :
 
 manifypods :
@@ -863,10 +860,7 @@ dynamic :
 
 static :
 
-realclean : clean
-
 clean :
-	%s %s
 
 install :
 

--- a/t/WriteEmptyMakefile.t
+++ b/t/WriteEmptyMakefile.t
@@ -12,7 +12,7 @@ use Cwd; my $cwd = getcwd; END { chdir $cwd } # so File::Temp can cleanup
 chdir $tmpdir;
 
 use strict;
-use Test::More tests => 6;
+use Test::More tests => 5;
 
 use ExtUtils::MakeMaker qw(WriteEmptyMakefile);
 use TieOut;
@@ -20,18 +20,18 @@ use TieOut;
 can_ok __PACKAGE__, 'WriteEmptyMakefile';
 
 eval { WriteEmptyMakefile("something"); };
-like $@, qr/Need an even number of args/, 'correct exception';
+like $@, qr/Need an even number of args/;
+
 
 {
-    ok( (my $stdout = tie *STDOUT, 'TieOut' ), 'tie stdout');
+    ok( my $stdout = tie *STDOUT, 'TieOut' );
 
-    ok !-e 'wibble', 'no wibble';
+    ok !-e 'wibble';
     END { 1 while unlink 'wibble' }
 
     WriteEmptyMakefile(
         NAME            => "Foo",
         FIRST_MAKEFILE  => "wibble",
     );
-    ok -e 'wibble', 'yes wibble';
-    ok !-d '_eumm', 'no _eumm lying around';
+    ok -e 'wibble';
 }

--- a/t/WriteEmptyMakefile.t
+++ b/t/WriteEmptyMakefile.t
@@ -33,5 +33,5 @@ like $@, qr/Need an even number of args/, 'correct exception';
         FIRST_MAKEFILE  => "wibble",
     );
     ok -e 'wibble', 'yes wibble';
-    ok !-d 'blib/_eumm', 'no _eumm lying around';
+    ok !-d '_eumm', 'no _eumm lying around';
 }

--- a/t/basic.t
+++ b/t/basic.t
@@ -24,7 +24,7 @@ use ExtUtils::MM;
 use Test::More
     !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
     ? (skip_all => "cross-compiling and make not available")
-    : (tests => 190);
+    : (tests => 184);
 use File::Find;
 use File::Spec;
 use File::Path;
@@ -195,7 +195,6 @@ sub check_dummy_inst {
     ok( $files{'program'},      '  program installed'  );
     ok( $files{'.packlist'},    '  packlist created'   );
     ok( $files{'perllocal.pod'},'  perllocal.pod created' );
-    ok( !$files{'_eumm'},        '  should not be an _eumm' );
     \%files;
 }
 

--- a/t/meta_convert.t
+++ b/t/meta_convert.t
@@ -13,7 +13,6 @@ my $tmpdir = tempdir( DIR => 't', CLEANUP => 1 );
 use Cwd; my $cwd = getcwd; END { chdir $cwd } # so File::Temp can cleanup
 chdir $tmpdir or die "chdir $tmpdir: $!";
 
-my $METAJSON = File::Spec->catfile('_eumm', 'META_new.json');
 my $EMPTY = qr/['"]?version['"]?\s*:\s*['"]['"]/;
 my @DATA = (
     [
@@ -104,8 +103,6 @@ sub run_test {
         }
         ok 1, "$label metafile_target";
         like join("", @warnings), $expected, "$label right warning";
-        skip "no $METAJSON", 1 unless -r $METAJSON;
-        my $content = do { open my $fh, '<', $METAJSON or skip "$METAJSON: $!", 1; local $/; <$fh>; };
-        like $content, $metadata_re, "$label metadata";
+        like $ret, $metadata_re, "$label metadata";
     }
 }

--- a/t/meta_convert.t
+++ b/t/meta_convert.t
@@ -13,7 +13,7 @@ my $tmpdir = tempdir( DIR => 't', CLEANUP => 1 );
 use Cwd; my $cwd = getcwd; END { chdir $cwd } # so File::Temp can cleanup
 chdir $tmpdir or die "chdir $tmpdir: $!";
 
-my $METAJSON = File::Spec->catfile('blib', '_eumm', 'META_new.json');
+my $METAJSON = File::Spec->catfile('_eumm', 'META_new.json');
 my $EMPTY = qr/['"]?version['"]?\s*:\s*['"]['"]/;
 my @DATA = (
     [


### PR DESCRIPTION
This reverts the changes adding the _eumm or blib/_eumm directory.

blib is meant to be created by the pm_to_blib make target, so creating it during configure leads to issues.

Having an _eumm directory in the top level is what we want long term, but adding files like that will lead to them being unintentionally shipped with many dists since _eumm won't be listed in MANIFEST.SKIP files normally.

We could possibly add additional encoding to deal with part of what _eumm is meant to fix.  But this PR leaves us no worse off than the current stable release, and should fix the last known regression listed in #235.