### PR TITLE
parse version from a block package declaration

### DIFF
--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -2869,7 +2869,7 @@ sub parse_version {
         next if $inpod || /^\s*#/;
         chop;
         next if /^\s*(if|unless|elsif)/;
-        if ( m{^ \s* package \s+ \w[\w\:\']* \s+ (v?[0-9._]+) \s* ;  }x ) {
+        if ( m{^ \s* package \s+ \w[\w\:\']* \s+ (v?[0-9._]+) \s* (;|\{)  }x ) {
             local $^W = 0;
             $result = $1;
         }

--- a/t/parse_version.t
+++ b/t/parse_version.t
@@ -81,6 +81,35 @@ our $VERSION = 2.34;
 END
 }
 
+if( $] >= 5.014 ) {
+    $versions{'package Foo 1.23 { }'         } = '1.23';
+    $versions{'package Foo::Bar 1.23 { }'    } = '1.23';
+    $versions{'package Foo v1.2.3 { }'       } = 'v1.2.3';
+    $versions{'package Foo::Bar v1.2.3 { }'  } = 'v1.2.3';
+    $versions{' package Foo::Bar 1.23 { }'   } = '1.23';
+    $versions{"package Foo'Bar 1.23 { }"     } = '1.23';
+    $versions{"package Foo::Bar 1.2.3 { }"   } = '1.2.3';
+    $versions{'package Foo 1.230 { }'        } = '1.230';
+    $versions{'package Foo 1.23_01 { }'      } = '1.23_01';
+    $versions{'package Foo v1.23_01 { }'     } = 'v1.23_01';
+    $versions{<<'END'}                      = '1.23';
+package Foo 1.23 {
+our $VERSION = 2.34;
+}
+END
+
+    $versions{<<'END'}                      = '2.34';
+our $VERSION = 2.34;
+package Foo 1.23 { }
+END
+
+    $versions{<<'END'}                      = '2.34';
+package Foo::100 {
+our $VERSION = 2.34;
+}
+END
+}
+
 if ( $] > 5.009 && $] < 5.012 ) {
   delete $versions{'$VERSION = -1.0'};
 }


### PR DESCRIPTION
It would be nice for MM to be able to parse a version from a block package declaration, since Module::Metadata and PAUSE both seem to be able to handle this.