### PR TITLE
t/echo.t needs SHELL env for Win32 gmake

### DIFF
--- a/t/echo.t
+++ b/t/echo.t
@@ -33,6 +33,9 @@ $mm->init_tools;  # need ECHO
 # Run Perl with the currently installing MakeMaker
 $mm->{$_} .= q[ "-I$(INST_ARCHLIB)" "-I$(INST_LIB)"] for qw( PERLRUN FULLPERLRUN ABSPERLRUN );
 
+#see sub specify_shell
+my $shell = $^O eq 'MSWin32' && $mm->is_make_type('gmake') ? $ENV{COMSPEC} : undef;
+
 #------------------- Testing functions
 
 sub test_for_echo {
@@ -53,6 +56,7 @@ sub test_for_echo {
         for my $key (qw(INST_ARCHLIB INST_LIB PERL ABSPERL ABSPERLRUN ECHO)) {
             print $makefh "$key=$mm->{$key}\n";
         }
+        print $makefh "SHELL=$shell\n" if defined $shell;
 
         print $makefh "all :\n";
         for my $args (@$calls) {


### PR DESCRIPTION
Win32 gmake prefers "sh.exe" (IE bash) over "cmd.exe" if it finds sh.exe
in PATH. Win32 Git usually comes with sh.exe. Running sh.exe causes
problems and isn't a supported build config for native (not Cygwin)
Win32 perl. See also
https://rt.perl.org/Public/Bug/Display.html?id=123440#txn-1374997

Fixes:
---------------------------------

    ok 8 - something.txt exists
    not ok 9 - contents#   Failed test 'contents'
    #   at t/echo.t line 69.
    #          got: '$
    # '
    #     expected: '$something$
    # '
    # Testing variables escaped
    # Temp dir: C:\Users\Owner\AppData\Local\Temp\gGwL2kl3Oh
    ok 10 - make: variables escaped
