### PR TITLE
MM_Unix->lsdir: fixes

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -64,7 +64,6 @@ my $MM = WriteMakefile(
         'File::Spec'     => 0.8,               # splitpath(), rel2abs()
         'Pod::Man'       => 0,                 # manifypods needs Pod::Man
         'File::Basename' => 0,
-        DirHandle        => 0,
         'Data::Dumper'   => 0,
         ($] > 5.008 ? (Encode => 0) : ()),
     },

--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -2426,7 +2426,7 @@ sub lsdir {
     $dh->open(defined($dir) ? $dir : '.') or return ();
     @ls = $dh->read;
     $dh->close;
-    @ls = grep(/$regex/, @ls) if $regex;
+    @ls = grep(/$regex/, @ls) if defined $regex;
     @ls;
 }
 

--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -7,7 +7,6 @@ use strict;
 use Carp;
 use ExtUtils::MakeMaker::Config;
 use File::Basename qw(basename dirname);
-use DirHandle;
 
 our %Config_Override;
 
@@ -2419,13 +2418,12 @@ all entries in the directory that match the regular expression.
 =cut
 
 sub lsdir {
-    my($self) = shift;
-    my($dir, $regex) = @_;
-    my(@ls);
-    my $dh = new DirHandle;
-    $dh->open(defined($dir) ? $dir : '.') or return ();
-    @ls = $dh->read;
-    $dh->close;
+    #  $self
+    my(undef, $dir, $regex) = @_;
+    opendir(my $dh, defined($dir) ? $dir : ".")
+        or return;
+    my @ls = readdir $dh;
+    closedir $dh;
     @ls = grep(/$regex/, @ls) if defined $regex;
     @ls;
 }

--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -2423,7 +2423,7 @@ sub lsdir {
     my($dir, $regex) = @_;
     my(@ls);
     my $dh = new DirHandle;
-    $dh->open($dir || ".") or return ();
+    $dh->open(defined($dir) ? $dir : '.') or return ();
     @ls = $dh->read;
     $dh->close;
     @ls = grep(/$regex/, @ls) if $regex;


### PR DESCRIPTION
Fixes for `MM_Unix->lsdir`:
- when the directort name is "0"
- when the regex is "0"
- drop use of DirHandle. Just use opendir/readdir/closedir.