### PR TITLE
Add 'if $Verbose' to 2 flush() print statements

### DIFF
--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -1222,8 +1222,8 @@ sub flush {
     my $self = shift;
 
     my $finalname = $self->{MAKEFILE};
-    printf "Generating a %s %s\n", $self->make_type, $finalname;
-    print "Writing $finalname for $self->{NAME}\n";
+    printf "Generating a %s %s\n", $self->make_type, $finalname if $Verbose || !$self->{PARENT};;
+    print "Writing $finalname for $self->{NAME}\n" if $Verbose || !$self->{PARENT};;
 
     unlink($finalname, "MakeMaker.tmp", $Is_VMS ? 'Descrip.MMS' : ());
 

--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -1222,8 +1222,8 @@ sub flush {
     my $self = shift;
 
     my $finalname = $self->{MAKEFILE};
-    printf "Generating a %s %s\n", $self->make_type, $finalname if $Verbose || !$self->{PARENT};;
-    print "Writing $finalname for $self->{NAME}\n" if $Verbose || !$self->{PARENT};;
+    printf "Generating a %s %s\n", $self->make_type, $finalname if $Verbose || !$self->{PARENT};
+    print "Writing $finalname for $self->{NAME}\n" if $Verbose || !$self->{PARENT};
 
     unlink($finalname, "MakeMaker.tmp", $Is_VMS ? 'Descrip.MMS' : ());
 


### PR DESCRIPTION
For distributions with lots of sub-modules, the constant chatter of "Generating a Unix-style Makefile\nWriting Makefile for My::ModuleA" can get in the way of identifying problems during Makefile generation.  Most other print statements in MakeMaker.pm (that aren't warnings) have some form of 'if $Verbose' postfix to cut down on chatter.  This patch also permits the printing of those lines for the top-level Makefile.

Sorry about the unhelpful branch name.