### PR TITLE
fix 5.6 compat by removing indexed sprintf

### DIFF
--- a/lib/ExtUtils/Command/MM.pm
+++ b/lib/ExtUtils/Command/MM.pm
@@ -214,8 +214,8 @@ sub perllocal_install {
                            : @ARGV;
 
     my $pod;
-    $pod = sprintf <<'POD', scalar(localtime), $type, $name;
- =head2 %s: C<%s> L<%3$s|%3$s>
+    $pod = sprintf <<'POD', scalar(localtime), $type, $name, $name;
+ =head2 %s: C<%s> L<%s|%s>
 
  =over 4
 


### PR DESCRIPTION
There is a helper function in ExtUtils::MakeMaker for this, but
that seems excessive to load in EU::Command::MM.