### PR TITLE
Fix regression with small fractional numeric versions

### DIFF
--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -452,9 +452,14 @@ sub new {
                 {
                   bad_version_hook => sub {
                     #no warnings 'numeric'; # module doesn't use warnings
-                    my ($fallback) = $_[0] ? ($_[0] =~ /^([0-9.]+)/) : 0;
-                    $fallback += 0;
-                    carp "Unparsable version '$_[0]' for prerequisite $_[1] treated as $fallback";
+                    my $fallback;
+                    if ( $_[0] =~ m!^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$! ) {
+                      $fallback = sprintf "%f", $_[0];
+                    } else {
+                      ($fallback) = $_[0] ? ($_[0] =~ /^([0-9.]+)/) : 0;
+                      $fallback += 0;
+                      carp "Unparsable version '$_[0]' for prerequisite $_[1] treated as $fallback";
+                    }
                     version->new($fallback);
                   },
                 },
@@ -472,9 +477,13 @@ sub new {
                     next;
                 }
                 else {
-                    my ($fallback) = $_[0] ? ($_[0] =~ /^([0-9.]+)/) : 0;
-                    $fallback += 0;
-                    carp "Unparsable version '$version' for prerequisite $module treated as $fallback (CPAN::Meta::Requirements not available)";
+                    if ( $version =~ m!^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$! ) {
+                      $fallback = sprintf "%f", $version;
+                    } else {
+                      ($fallback) = $version ? ($version =~ /^([0-9.]+)/) : 0;
+                      $fallback += 0;
+                      carp "Unparsable version '$version' for prerequisite $module treated as $fallback (CPAN::Meta::Requirements not available)";
+                    }
                 }
                 $self->{$key}->{$module} = $fallback;
             }
@@ -585,9 +594,14 @@ END
           $pr_version = 0 if $pr_version eq 'undef';
           if ( !eval { version->new( $pr_version ); 1 } ) {
             #no warnings 'numeric'; # module doesn't use warnings
-            my ($fallback) = $pr_version ? ($pr_version =~ /^([0-9.]+)/) : 0;
-            $fallback += 0;
-            carp "Unparsable version '$pr_version' for installed prerequisite $prereq treated as $fallback";
+            my $fallback;
+            if ( $pr_version =~ m!^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$! ) {
+              $fallback = sprintf '%f', $pr_version;
+            } else {
+              ($fallback) = $pr_version ? ($pr_version =~ /^([0-9.]+)/) : 0;
+              $fallback += 0;
+              carp "Unparsable version '$pr_version' for installed prerequisite $prereq treated as $fallback";
+            }
             $pr_version = $fallback;
           }
         }

--- a/t/vstrings.t
+++ b/t/vstrings.t
@@ -41,6 +41,7 @@ my @DATA = (
   [ V2DecimalString => 'v1.2', qr/^$/, '2-part v-decimal string', $UNPARSABLERE ],
   [ V3DecimalString => 'v1.2.3', qr/^$/, '3-part v-Decimal String', $UNPARSABLERE ],
   [ RangeString => '>= 5.0, <= 6.0', qr/^$/, 'Version range', $UNPARSABLERE ],
+  [ Scientific => 0.000005, qr/^$/, 'Scientific Notation' ],
 );
 
 plan tests => (1 + (@DATA * 4));


### PR DESCRIPTION
If a version number is passed in numeric form, C::M::R will use its stringified form for all its processing.
This doesn't play well with small fractional versions like 0.000005, which will be stringified as '5e-06',
and thus rejected as invalid.

EUMM then proceeded misparse the rejected number, so in the above case it became '5'

Also added test-case to vstrings.t