### PR TITLE
Since dlltool is no longer used, remove some unnecessary code/tests r…

### DIFF
--- a/lib/ExtUtils/MM_Win32.pm
+++ b/lib/ExtUtils/MM_Win32.pm
@@ -32,7 +32,7 @@ $VERSION = eval $VERSION;
 
 $ENV{EMXSHELL} = 'sh'; # to run `commands`
 
-my ( $BORLAND, $GCC, $MSVC, $DLLTOOL ) = _identify_compiler_environment( \%Config );
+my ( $BORLAND, $GCC, $MSVC ) = _identify_compiler_environment( \%Config );
 
 sub _identify_compiler_environment {
 	my ( $config ) = @_;
@@ -40,9 +40,8 @@ sub _identify_compiler_environment {
 	my $BORLAND = $config->{cc} =~ /\bbcc/i ? 1 : 0;
 	my $GCC     = $config->{cc} =~ /\bgcc\b/i ? 1 : 0;
 	my $MSVC    = $config->{cc} =~ /\b(?:cl|icl)/i ? 1 : 0; # MSVC can come as clarm.exe, icl=Intel C
-	my $DLLTOOL = $config->{dlltool} || 'dlltool';
 
-	return ( $BORLAND, $GCC, $MSVC, $DLLTOOL );
+	return ( $BORLAND, $GCC, $MSVC );
 }
 
 

--- a/t/MM_Win32.t
+++ b/t/MM_Win32.t
@@ -280,7 +280,7 @@ unlink "${script_name}$script_ext" if -f "${script_name}$script_ext";
 
         my @cc_env = ExtUtils::MM_Win32::_identify_compiler_environment( $config );
 
-        my %cc_env = ( BORLAND => $cc_env[0], GCC => $cc_env[1], MSVC => $cc_env[2], DLLTOOL => $cc_env[3] );
+        my %cc_env = ( BORLAND => $cc_env[0], GCC => $cc_env[1], MSVC => $cc_env[2] );
 
         return \%cc_env;
     }
@@ -299,16 +299,6 @@ unlink "${script_name}$script_ext" if -f "${script_name}$script_ext";
     }
 
     my @tests = (
-        {
-            config => {},
-            key => 'DLLTOOL', expect => 'dlltool',
-            desc => 'empty dlltool defaults to "dlltool"',
-        },
-        {
-            config => { dlltool => 'test' },
-            key => 'DLLTOOL', expect => 'test',
-            desc => 'dlltool value is taken over verbatim from %Config, if set',
-        },
         {
             config => {},
             key => 'GCC', expect => 0,


### PR DESCRIPTION
…elated to it.

dlltool is gone as of 44e95e717372abe2b0a6ee55de4b686760b65360, so this bit of code and tests aren't needed and will no doubt be confusing to someone in the future.