### PR TITLE
check for ascii locale using normalized name

### DIFF
--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -12,7 +12,7 @@ use Carp;
 use File::Path;
 my $CAN_DECODE = eval { require ExtUtils::MakeMaker::Locale; }; # 2 birds, 1 stone
 eval { ExtUtils::MakeMaker::Locale::reinit('UTF-8') }
-  if $CAN_DECODE and $ExtUtils::MakeMaker::Locale::ENCODING_LOCALE eq 'US-ASCII';
+  if $CAN_DECODE and Encode::find_encoding('locale')->name eq 'ascii';
 
 our $Verbose = 0;       # exported
 our @Parent;            # needs to be localized


### PR DESCRIPTION
The codeset returned by I18N::Langinfo::langinfo can have multiple
forms, and may be an alias of ascii.  For example, on an Ubuntu 14.04
machine, it will return ANSI_X3.4-1968 under LANG=C.  Rather than
checking for 'US-ASCII' directly, check the name of the encoding object
returned for 'locale'.