### PR TITLE
POD: added examples for running tests in subdirs

### DIFF
--- a/lib/ExtUtils/MakeMaker/FAQ.pod
+++ b/lib/ExtUtils/MakeMaker/FAQ.pod
@@ -120,6 +120,29 @@ have multiple modules to work with.  It also ensures that the module
 goes through its full installation process which may modify it.
 Again, L<local::lib> may assist you here.
 
+=item How can I organize tests into subdirectories and have them run?
+
+Let's take the following test directory structure:
+
+    t/foo/sometest.t
+    t/bar/othertest.t
+    t/bar/baz/anothertest.t
+
+Now, inside of the C<WriteMakeFile()> function in your F<Makefile.PL>, specify
+where your tests are located with the C<test> directive:
+
+    test => {TESTS => 't/*.t t/*/*.t' t/*/*/*.t'}
+
+The first entry in the string will run all tests in the top-level F<t/> 
+directory. The second will run all test files located in any subdirectory under
+F<t/>. The third, runs all test files within any subdirectory within any other
+subdirectory located under F<t/>.
+
+Note that you do not have to use wildcards. You can specify explicitly which
+subdirectories to run tests in:
+
+    test => {TESTS => 't/*.t t/foo/*.t t/bar/baz/*.t'}
+
 =item PREFIX vs INSTALL_BASE from Module::Build::Cookbook
 
 The behavior of PREFIX is complicated and depends closely on how your

--- a/lib/ExtUtils/MakeMaker/Tutorial.pod
+++ b/lib/ExtUtils/MakeMaker/Tutorial.pod
@@ -104,8 +104,39 @@ is F<lib/Foo/Bar.pm>.
 =item t/
 
 Tests for your modules go here.  Each test filename ends with a .t.
-So F<t/foo.t>/  'make test' will run these tests.  The directory is flat,
-you cannot, for example, have t/foo/bar.t run by 'make test'.
+So F<t/foo.t>/  'make test' will run these tests.
+
+Typically, the F<t/> test directory is flat, with all test files located
+directly within it. However, you can nest tests within subdirectories, for
+example:
+
+    t/foo/subdir_test.t
+
+To do this, you need to inform C<WriteMakeFile()> in your I<Makefile.PL> file
+in the following fashion:
+
+    test => {TESTS => 't/*.t t/*/*.t'}
+
+That will run all tests in F<t/>, as well as all tests in all subdirectories
+that reside under F<t/>. You can nest as deeply as makes sense for your project. 
+Simply add another entry in the test location string. For example, to test:
+
+    t/foo/bar/subdir_test.t
+
+You would use the following C<test> directive:
+
+    test => {TESTS => 't/*.t t/*/*/*.t}
+
+Note that in the above example, tests in the first subdirectory will not be
+run. To run all tests in the intermediary subdirectory preceeding the one
+the test files are in, you need to explicitly note it:
+
+    test => {TESTS => 't/*.t t/*/*.t t/*/*/*.t'}
+
+You don't need to specify wildcards if you only want to test within specific
+subdirectories. The following example will only run tests in F<t/foo>:
+
+    test => {TESTS => 't/foo/*.t'}
 
 Tests are run from the top level of your distribution.  So inside a test
 you would refer to ./lib to enter the lib directory, for example.


### PR DESCRIPTION
Although there are no code changes in this PR, I still verified the examples work back to v5.6.2 on both Linux and Windows.

Example: `test  => { TESTS => 't/*.t t/*/*.t t/*/*/*.t' }`

```
v5.24.0

PERL_DL_NONLAZY=1 "/home/ubuntu/perl5/perlbrew/perls/perl-5.24.0/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t t/*/*.t t/*/*/*.t
t/00-load.t ............ ok
t/a/00-subdir-a.t ...... ok
t/a/b/00-subdir-a-b.t .. ok
t/c/00-subdir-c.t ...... ok
All tests successful.
```

```
v5.6.2

PERL_DL_NONLAZY=1 /home/ubuntu/perl5/perlbrew/perls/perl-5.6.2/bin/perl "-MExtUtils::Command::MM" "-e" "test_harness(0, 'blib/lib', 'blib/arch')" t/*.t t/*/*.t t/*/*/*.t
t/00-load..............ok
t/a/00-subdir-a........ok
t/a/b/00-subdir-a-b....ok
t/c/00-subdir-c........ok
All tests successful.
```

If these changes are accepted, I'll update any other docs with this information that anyone feels could benefit from these examples.