### PR TITLE
prevent EUMM::Locale from warning with old Win32.pm

### DIFF
--- a/lib/ExtUtils/MakeMaker/Locale.pm
+++ b/lib/ExtUtils/MakeMaker/Locale.pm
@@ -28,11 +28,8 @@ sub _init {
 	    eval {
 		unless (defined &GetConsoleCP) {
 		    require Win32;
-                    # no point falling back to Win32::GetConsoleCP from this
-                    # as added same time, 0.45
-                    eval { Win32::GetConsoleCP() };
                     # manually "import" it since Win32->import refuses
-		    *GetConsoleCP = sub { &Win32::GetConsoleCP } unless $@;
+		    *GetConsoleCP = sub { &Win32::GetConsoleCP } if defined &Win32::GetConsoleCP;
 		}
 		unless (defined &GetConsoleCP) {
 		    require Win32::API;
@@ -52,18 +49,17 @@ sub _init {
                     require Win32;
                     eval { Win32::GetConsoleCP() };
                     # manually "import" it since Win32->import refuses
-                    *GetInputCP = sub { &Win32::GetConsoleCP } unless $@;
-                    *GetOutputCP = sub { &Win32::GetConsoleOutputCP } unless $@;
+                    *GetInputCP = sub { &Win32::GetConsoleCP } if defined &Win32::GetConsoleCP;
+                    *GetOutputCP = sub { &Win32::GetConsoleOutputCP } if defined &Win32::GetConsoleOutputCP;
                 };
                 unless (defined &GetInputCP) {
                     eval {
                         # try Win32::Console module for codepage to use
                         require Win32::Console;
-                        eval { Win32::Console::InputCP() };
                         *GetInputCP = sub { &Win32::Console::InputCP }
-                            unless $@;
+                            if defined &Win32::Console::InputCP;
                         *GetOutputCP = sub { &Win32::Console::OutputCP }
-                            unless $@;
+                            unless if defined &Win32::Console::OutputCP;
                     };
                 }
                 unless (defined &GetInputCP) {

--- a/lib/ExtUtils/MakeMaker/Locale.pm
+++ b/lib/ExtUtils/MakeMaker/Locale.pm
@@ -59,7 +59,7 @@ sub _init {
                         *GetInputCP = sub { &Win32::Console::InputCP }
                             if defined &Win32::Console::InputCP;
                         *GetOutputCP = sub { &Win32::Console::OutputCP }
-                            unless if defined &Win32::Console::OutputCP;
+                            if defined &Win32::Console::OutputCP;
                     };
                 }
                 unless (defined &GetInputCP) {


### PR DESCRIPTION
Older DynaLoader inherits from AutoLoader, so nonexistent function calls
will trigger AUTOLOAD, but with a warning over deprecated behavior.

With an older Win32.pm that doesn't have the functions we are looking
for, checking for their existence with a call in an eval will trigger
this warning.  That warning breaks our tests.

Replacing the eval+call with a defined check on the function is a more
appropriate way to check for functions, and will avoid the warnings.

This unfortunately means we diverge from Encode::Locale.  Hopefully the
next version of that module will include this fix.