### PR TITLE
make test subdirs: fix typos, added blurb in MakeMaker POD

### DIFF
--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -1466,6 +1466,23 @@ MakeMaker also checks for any files matching glob("t/*.t"). It will
 execute all matching files in alphabetical order via the
 L<Test::Harness> module with the C<-I> switches set correctly.
 
+You can also organize your tests within subdirectories in the F<t/> directory.
+To do so, use the F<test> directive in your I<Makefile.PL>. For example, if you
+had tests in:
+
+    t/foo
+    t/foo/bar
+
+You could tell make to run tests in both of those directories with the
+following directives:
+
+    test => {TESTS => 't/*/*.t t/*/*/*.t'}
+    test => {TESTS => 't/foo/*.t t/foo/bar/*.t'}
+
+The first will run all test files in all first-level subdirectories and all
+subdirectories they contain. The second will run tests in only the F<t/foo>
+and F<t/foo/bar>.
+
 If you'd like to see the raw output of your tests, set the
 C<TEST_VERBOSE> variable to true.
 

--- a/lib/ExtUtils/MakeMaker/FAQ.pod
+++ b/lib/ExtUtils/MakeMaker/FAQ.pod
@@ -131,7 +131,7 @@ Let's take the following test directory structure:
 Now, inside of the C<WriteMakeFile()> function in your F<Makefile.PL>, specify
 where your tests are located with the C<test> directive:
 
-    test => {TESTS => 't/*.t t/*/*.t' t/*/*/*.t'}
+    test => {TESTS => 't/*.t t/*/*.t t/*/*/*.t'}
 
 The first entry in the string will run all tests in the top-level F<t/> 
 directory. The second will run all test files located in any subdirectory under

--- a/lib/ExtUtils/MakeMaker/Tutorial.pod
+++ b/lib/ExtUtils/MakeMaker/Tutorial.pod
@@ -104,7 +104,7 @@ is F<lib/Foo/Bar.pm>.
 =item t/
 
 Tests for your modules go here.  Each test filename ends with a .t.
-So F<t/foo.t>/  'make test' will run these tests.
+So F<t/foo.t>  'make test' will run these tests.
 
 Typically, the F<t/> test directory is flat, with all test files located
 directly within it. However, you can nest tests within subdirectories, for


### PR DESCRIPTION
Fixed a couple of typos that I had in yesterday's PR, and added a short blurb about test subdirs in the main MakeMaker.pm POD