### PR TITLE
CVE-2016-1238: avoid loading VMS::Feature from the default .

### DIFF
--- a/lib/ExtUtils/Command.pm
+++ b/lib/ExtUtils/Command.pm
@@ -20,7 +20,10 @@ if( $Is_VMS ) {
     my $vms_efs;
     my $vms_case;
 
-    if (eval { local $SIG{__DIE__}; require VMS::Feature; }) {
+    if (eval { local $SIG{__DIE__};
+               local @INC = @INC;
+               pop @INC if $INC[-1] eq '.';
+               require VMS::Feature; }) {
         $vms_unix_rpt = VMS::Feature::current("filename_unix_report");
         $vms_efs = VMS::Feature::current("efs_charset");
         $vms_case = VMS::Feature::current("efs_case_preserve");


### PR DESCRIPTION
ExtUtils::Command attempts to load VMS::Feature on VMS, ignoring
errors when loading it.

If VMS has such a thing as a global, world-writable directory, like
/tmp on POSIX systems, and VMS::Feature is not installed, and a user
runs a program that loads ExtUtils::Command with such a directory
as the current directory, an attacker can create VMS/Feature.pm in
that directory to run code as the original user.

This removes the default . from the end of @INC to prevent that.