### PR TITLE
Make perllocal.pod files reproducible

### DIFF
--- a/lib/ExtUtils/Command/MM.pm
+++ b/lib/ExtUtils/Command/MM.pm
@@ -219,7 +219,8 @@ sub perllocal_install {
                            : @ARGV;
 
     my $pod;
-    $pod = sprintf <<'POD', scalar(localtime), $type, $name, $name;
+    my $time = gmtime($ENV{SOURCE_DATE_EPOCH} || time);
+    $pod = sprintf <<'POD', scalar($time), $type, $name, $name;
  =head2 %s: C<%s> L<%s|%s>
 
  =over 4

--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -3869,7 +3869,7 @@ Obsolete, deprecated method. Not used since Version 5.21.
 sub writedoc {
 # --- perllocal.pod section ---
     my($self,$what,$name,@attribs)=@_;
-    my $time = localtime;
+    my $time = gmtime($ENV{SOURCE_DATE_EPOCH} || time);
     print "=head2 $time: $what C<$name>\n\n=over 4\n\n=item *\n\n";
     print join "\n\n=item *\n\n", map("C<$_>",@attribs);
     print "\n\n=back\n\n";


### PR DESCRIPTION
As per https://bugs.debian.org/834190 and https://bugs.debian.org/835815 this patch makes the perllocal.pod files generated by ExtUtils::MakeMaker be reproducible across builds. This patch is part of the Reproducible Builds[0](https://reproducible-builds.org/) project:
