### PR TITLE
META_ADD/MERGE default meta version based on each other

### DIFF
--- a/lib/ExtUtils/MM_Any.pm
+++ b/lib/ExtUtils/MM_Any.pm
@@ -1319,7 +1319,8 @@ sub metafile_data {
     my $v1_add = _metaspec_version($meta_add) !~ /^2/;
 
     for my $frag ($meta_add, $meta_merge) {
-        $frag = CPAN::Meta::Converter->new($frag, default_version => "1.4")->upgrade_fragment;
+        my $def_v = _metaspec_version($frag == $meta_add ? $meta_merge : $meta_add);
+        $frag = CPAN::Meta::Converter->new($frag, default_version => $def_v)->upgrade_fragment;
     }
 
     # if we upgraded a 1.x _ADD fragment, we gave it a prereqs key that

--- a/t/metafile_data.t
+++ b/t/metafile_data.t
@@ -17,7 +17,7 @@ use File::Temp;
 use Cwd;
 use MakeMaker::Test::Utils;
 
-plan tests => 31;
+plan tests => 33;
 require ExtUtils::MM_Any;
 
 sub mymeta_ok {
@@ -260,6 +260,62 @@ my @GENERIC_OUT = (
         },
         @GENERIC_OUT,
     },'TEST_REQUIRES meta-spec 2.0';
+}
+
+{
+    my $mm = $new_mm->(
+        @GENERIC_IN,
+    );
+    is_deeply $mm->metafile_data(
+        {
+            'configure_requires' => {
+                'Fake::Module1' => 1,
+            },
+            'prereqs' => {
+                @REQ20,
+                'test' => {
+                    'requires' => {
+                        'Fake::Module2' => 2,
+                    },
+                },
+            },
+        },
+        { 'meta-spec' => { 'version' => 2 }, }
+    ), {
+        prereqs => {
+            @REQ20,
+            test => { requires => { "Fake::Module2" => 2, }, },
+        },
+        @GENERIC_OUT,
+    }, 'META_ADD takes meta version from META_MERGE';
+}
+
+{
+    my $mm = $new_mm->(
+        @GENERIC_IN,
+    );
+    is_deeply $mm->metafile_data(
+        { 'meta-spec' => { 'version' => 2 }, },
+        {
+            'configure_requires' => {
+                'Fake::Module1' => 1,
+            },
+            'prereqs' => {
+                @REQ20,
+                'test' => {
+                    'requires' => {
+                        'Fake::Module2' => 2,
+                    },
+                },
+            },
+        },
+    ), {
+        prereqs => {
+            @REQ20,
+            test => { requires => { "Fake::Module2" => 2, }, },
+        },
+        @GENERIC_OUT,
+    }, 'META_MERGE takes meta version from META_ADD';
 }
 
 # Test _REQUIRES key priority over META_ADD


### PR DESCRIPTION
Prior to commit 91b7ff8b56d529cfcee575b7858878ea0d415a0d (released in
v7.05_13), META_ADD and META_MERGE will be erroneously mixed together
when processing.  This essentially means that if a meta-spec version is
specified in one, it will be used for the other as well.

Now that META_ADD and META_MERGE are properly kept separate, they can
specify data in different spec versions.  But if a version is only
specified in one, it makes sense to use it for the other as well.  This
also matches the old behavior, even if it was at the time unintentional.
