### PR TITLE
Eliminate an ancient, unneeded, dangerous call to Carp::longmess

### DIFF
--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -652,11 +652,6 @@ END
         }
     }
 
-    # This is for old Makefiles written pre 5.00, will go away
-    if ( Carp::longmess("") =~ /runsubdirpl/s ){
-        carp("WARNING: Please rerun 'perl Makefile.PL' to regenerate your Makefiles\n");
-    }
-
     my $newclass = ++$PACKNAME;
     local @Parent = @Parent;    # Protect against non-local exits
     {


### PR DESCRIPTION
WriteMakefile is calling `Carp::longmess("")` to generate a call stack, and searching it for "runsubdirpl". This is (I believe) to check for a condition where EUMM was upgraded during the process of installing dependencies for a module, and the old and new versions are incompatible in their handling of something or other. But runsubdirpl was removed sometime between EUMM 5.18 and 5.21, and 5.21 shipped with perl 5.002 in 1996. Therefore this condition can only happen with a deeply unsupported version of perl.

Calling Carp::longmess to generate a stacktrace is unnecessarily expensive, and also fraught with peril -- due to long-standing perl bugs, it's possible for perl to crash when Carp accesses @DB::args to populate the stacktrace (ref CPAN RT#72467, perl RT#104074, perl RT#125907), and this has in fact happened with the Makefile.PLs for net-snmp and XML-Parser in the past. Since this check has outlived its usefulness, remove it so it can't make trouble.