### PR TITLE
Fix multiple inheritance for c3

### DIFF
--- a/lib/ExtUtils/MM_VMS.pm
+++ b/lib/ExtUtils/MM_VMS.pm
@@ -15,12 +15,12 @@ BEGIN {
 
 use File::Basename;
 
-our $VERSION = '7.25_01';
+our $VERSION = '7.25_02';
 $VERSION = eval $VERSION;
 
 require ExtUtils::MM_Any;
 require ExtUtils::MM_Unix;
-our @ISA = qw( ExtUtils::MM_Any ExtUtils::MM_Unix );
+our @ISA = qw( ExtUtils::MM_Unix ExtUtils::MM_Any );
 
 use ExtUtils::MakeMaker qw($Verbose neatvalue _sprintf562);
 our $Revision = $ExtUtils::MakeMaker::Revision;

--- a/lib/ExtUtils/MM_Win32.pm
+++ b/lib/ExtUtils/MM_Win32.pm
@@ -26,8 +26,8 @@ use ExtUtils::MakeMaker qw(neatvalue _sprintf562);
 
 require ExtUtils::MM_Any;
 require ExtUtils::MM_Unix;
-our @ISA = qw( ExtUtils::MM_Any ExtUtils::MM_Unix );
-our $VERSION = '7.25_01';
+our @ISA = qw( ExtUtils::MM_Unix ExtUtils::MM_Any );
+our $VERSION = '7.25_02';
 $VERSION = eval $VERSION;
 
 $ENV{EMXSHELL} = 'sh'; # to run `commands`


### PR DESCRIPTION
With multiple inheritance (@ISA>1), the c3 mro
refuses to load the most specific after the least specific base class.
The general rule to avoid inconsistency for @ISA is
from most specific to least specific.

cperl switched to c3 already (perl5 might do later evtl.)
and fails with "Inconsistent hierarchy during C3 merge".

(The other culprit is usually Exporter at the front of an @ISA btw).