### PR TITLE
Only add static libraries that are installed under auto/

### DIFF
--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -2578,7 +2578,7 @@ $(MAKE_APERL_FILE) : static $(FIRST_MAKEFILE) pm_to_blib
 	return if $File::Find::name =~ m:\Q$installed_version\E\z:;
 	use Cwd 'cwd';
 	$static{cwd() . "/" . $_}++;
-    }, grep( -d $_, @{$searchdirs || []}) );
+    }, grep( -d $_, map { $self->catdir($_, 'auto') } @{$searchdirs || []}) );
 
     # We trust that what has been handed in as argument, will be buildable
     $static = [] unless $static;

--- a/t/03-xsstatic.t
+++ b/t/03-xsstatic.t
@@ -11,9 +11,6 @@ use MakeMaker::Test::Utils;
 use MakeMaker::Test::Setup::XS;
 use Test::More;
 
-plan skip_all => "Disabled as broken perl installs give false negative"
-  # if not static perl, and not author
-  unless !$Config{usedl} or $ENV{AUTHOR_TESTING};
 plan skip_all => "ExtUtils::CBuilder not installed or couldn't find a compiler"
   unless have_compiler();
 plan skip_all => 'Shared perl library' if $Config{useshrplib} eq 'true';


### PR DESCRIPTION
Some dists install their own static libraries to the archlib, which leads to build failures for `makeaperl`. This patch tries to eliminate that problem by only linking in static libraries in `$arch/auto/`.