### PR TITLE
Fix POD error in lib/ExtUtils/MakeMaker/FAQ.pod

### DIFF
--- a/lib/ExtUtils/MakeMaker/FAQ.pod
+++ b/lib/ExtUtils/MakeMaker/FAQ.pod
@@ -390,7 +390,9 @@ We recommend InfoZIP: L<http://www.info-zip.org/Zip.html>
 
 =head2 XS
 
-=head3 How do I prevent "object version X.XX does not match bootstrap parameter Y.YY" errors?
+=over 4
+
+=item How do I prevent "object version X.XX does not match bootstrap parameter Y.YY" errors?
 
 XS code is very sensitive to the module version number and will
 complain if the version number in your Perl module doesn't match.  If
@@ -405,13 +407,15 @@ WriteMakefile() arguments.
     depend => { '$(FIRST_MAKEFILE)' => '$(VERSION_FROM)' }
 
 
-=head3 How do I make two or more XS files coexist in the same directory?
+=item How do I make two or more XS files coexist in the same directory?
 
 Sometimes you need to have two and more XS files in the same package.
 There are three ways: C<XSMULTI>, separate directories, and bootstrapping
 one XS from another.
 
-=head4 XSMULTI
+=over 8
+
+=item XSMULTI
 
 Structure your modules so they are all located under F<lib>, such that
 C<Foo::Bar> is in F<lib/Foo/Bar.pm> and F<lib/Foo/Bar.xs>, etc. Have your
@@ -419,14 +423,14 @@ top-level C<WriteMakefile> set the variable C<XSMULTI> to a true value.
 
 Er, that's it.
 
-=head4 Separate directories
+=item Separate directories
 
 Put each XS files into separate directories, each with their own
 F<Makefile.PL>. Make sure each of those F<Makefile.PL>s has the correct
 C<CFLAGS>, C<INC>, C<LIBS> etc. You will need to make sure the top-level
 F<Makefile.PL> refers to each of these using C<DIR>.
 
-=head4 Bootstrapping
+=item Bootstrapping
 
 Let's assume that we have a package C<Cool::Foo>, which includes
 C<Cool::Foo> and C<Cool::Bar> modules each having a separate XS
@@ -543,6 +547,8 @@ This tip has been brought to you by Nick Ing-Simmons and Stas Bekman.
 
 An alternative way to achieve this can be seen in L<Gtk2::CodeGen>
 and L<Glib::CodeGen>.
+
+=back
 
 =back
 


### PR DESCRIPTION
This is for the CPAN Pull Request Challenge.

lib/ExtUtils/MakeMaker/FAQ.pod had a POD error:
```
*** ERROR: =back without previous =over at line 547 in file lib/ExtUtils/MakeMaker/FAQ.pod
lib/ExtUtils/MakeMaker/FAQ.pod has 1 pod syntax error.
```

The XS section used =head3 and =head4 instead of =over lists. I changed it to lists so it would be consistent with the other categories.