### PR TITLE
check specifies meta versions of META_ADD/META_MERGE before upgrading

### DIFF
--- a/lib/ExtUtils/MM_Any.pm
+++ b/lib/ExtUtils/MM_Any.pm
@@ -1329,8 +1329,9 @@ sub metafile_data {
     # needs to be based on the original version
     my $v1_add = _metaspec_version($meta_add) !~ /^2/;
 
+    my ($add_v, $merge_v) = map _metaspec_version($_), $meta_add, $meta_merge;
     for my $frag ($meta_add, $meta_merge) {
-        my $def_v = _metaspec_version($frag == $meta_add ? $meta_merge : $meta_add);
+        my $def_v = $frag == $meta_add ? $merge_v : $add_v;
         $frag = CPAN::Meta::Converter->new($frag, default_version => $def_v)->upgrade_fragment;
     }
 

--- a/t/metafile_data.t
+++ b/t/metafile_data.t
@@ -17,7 +17,7 @@ use File::Temp;
 use Cwd;
 use MakeMaker::Test::Utils;
 
-plan tests => 33;
+plan tests => 35;
 require ExtUtils::MM_Any;
 
 sub mymeta_ok {
@@ -268,6 +268,54 @@ my @GENERIC_OUT = (
     );
     is_deeply $mm->metafile_data(
         {
+            resources => {
+                homepage => "https://metacpan.org/release/ExtUtils-MakeMaker",
+                repository => "http://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker",
+            },
+        },
+        { @METASPEC14 },
+    ), {
+        prereqs => { @REQ20 },
+        resources => {
+            homepage => "https://metacpan.org/release/ExtUtils-MakeMaker",
+            repository => {
+                url => "http://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker",
+            },
+        },
+        @GENERIC_OUT,
+    }, 'META_ADD takes meta version 1.4 from META_MERGE';
+}
+
+{
+    my $mm = $new_mm->(
+        @GENERIC_IN,
+    );
+    is_deeply $mm->metafile_data(
+        { @METASPEC14 },
+        {
+            resources => {
+                homepage => "https://metacpan.org/release/ExtUtils-MakeMaker",
+                repository => "http://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker",
+            },
+        },
+    ), {
+        prereqs => { @REQ20 },
+        resources => {
+            homepage => "https://metacpan.org/release/ExtUtils-MakeMaker",
+            repository => {
+                url => "http://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker",
+            },
+        },
+        @GENERIC_OUT,
+    }, 'META_MERGE takes meta version 1.4 from META_ADD';
+}
+
+{
+    my $mm = $new_mm->(
+        @GENERIC_IN,
+    );
+    is_deeply $mm->metafile_data(
+        {
             'configure_requires' => {
                 'Fake::Module1' => 1,
             },
@@ -280,14 +328,14 @@ my @GENERIC_OUT = (
                 },
             },
         },
-        { 'meta-spec' => { 'version' => 2 }, }
+        { @METASPEC20 },
     ), {
         prereqs => {
             @REQ20,
             test => { requires => { "Fake::Module2" => 2, }, },
         },
         @GENERIC_OUT,
-    }, 'META_ADD takes meta version from META_MERGE';
+    }, 'META_ADD takes meta version 2 from META_MERGE';
 }
 
 {
@@ -295,7 +343,7 @@ my @GENERIC_OUT = (
         @GENERIC_IN,
     );
     is_deeply $mm->metafile_data(
-        { 'meta-spec' => { 'version' => 2 }, },
+        { @METASPEC20 },
         {
             'configure_requires' => {
                 'Fake::Module1' => 1,
@@ -315,7 +363,7 @@ my @GENERIC_OUT = (
             test => { requires => { "Fake::Module2" => 2, }, },
         },
         @GENERIC_OUT,
-    }, 'META_MERGE takes meta version from META_ADD';
+    }, 'META_MERGE takes meta version 2 from META_ADD';
 }
 
 # Test _REQUIRES key priority over META_ADD


### PR DESCRIPTION
We need the meta spec version as specified in each META_ fragment to use
as a default for the other.  Since we are upgrading the fragments
in-place, the meta version of META_ADD would always register as 2.  This
would result in META_MERGE always defaulting to being processed as 2,
unless it had a meta-spec version specified itself.

Pre-calculate the spec versions to use as defaults prior to making any
modifications to the fragments, so our upgrade process doen't affect the
expected versions.

Fixes RT#121913.