### PR TITLE
prune .a without extralibs.ld

### DIFF
--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -2547,6 +2547,8 @@ $(MAKE_APERL_FILE) : static $(FIRST_MAKEFILE) pm_to_blib
 
 	return unless m/\Q$self->{LIB_EXT}\E$/;
 
+	return unless -f 'extralibs.ld'; # this checks is a "proper" XS installation
+
         # Skip perl's libraries.
         return if m/^libperl/ or m/^perl\Q$self->{LIB_EXT}\E$/;
 

--- a/t/lib/MakeMaker/Test/Setup/XS.pm
+++ b/t/lib/MakeMaker/Test/Setup/XS.pm
@@ -150,6 +150,7 @@ $label2files{static} = +{
     q{LINKTYPE => 'static'},
   ),
   "blib/arch/auto/share/dist/x-y/libwhatevs$MM->{LIB_EXT}" => 'hi there', # mimic what File::ShareDir can do
+  "blib/arch/auto/Alien/ROOT/root/lib/root/root$MM->{LIB_EXT}" => 'hi there', # mimic Alien::ROOT that installs a .a without extralibs.ld
 };
 
 $label2files{subdirs} = +{


### PR DESCRIPTION
This fixes one of the two fails in Slaven's latest report.