### PR TITLE
Darwin: Recognize WriteMakefile(LIBS=>'-framework X'

### DIFF
--- a/lib/ExtUtils/Liblist/Kid.pm
+++ b/lib/ExtUtils/Liblist/Kid.pm
@@ -57,6 +57,11 @@ sub _unix_os2_ext {
     my ( $pwd )   = cwd();    # from Cwd.pm
     my ( $found ) = 0;
 
+    if ( $^O eq 'darwin' or $^O eq 'next' )  {
+        # 'escape' Mach-O ld -framework flags, so they aren't dropped later on
+        $potential_libs =~ s/(^|\s)(-(?:weak_|reexport_|lazy_)?framework)\s+(\S+)/$1-Wl,$2 -Wl,$3/g;
+    }
+
     foreach my $thislib ( split ' ', $potential_libs ) {
         my ( $custom_name ) = '';
 


### PR DESCRIPTION
ld(1) on NeXTSTEP and Darwin supports a `-framework` flag that specifies bundles
containing both library and header files.

Previously, these were dropped with an `Unrecognized argument in LIBS ignored`
warning. They are now 'escaped' with `-Wl,` so they may reach the linker.

macOS man page: http://www.unix.com/man-page/osx/1/ld/
NeXT man page: http://www.polarhome.com/service/man/?qf=ld&af=0&sf=0&of=NeXTSTEP&tf=2

[Live action demo](https://github.com/athreef/Graphics-Raylib/tree/EU-MM-framework-demo/XS): Current EU::MM drops the `-framework`, raises warnings and fails `make test`. The attached patch does none of these.