### PR TITLE
Add supports_param function

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -156,6 +156,7 @@ t/recurs.t
 t/revision.t
 t/several_authors.t
 t/split_command.t
+t/supports_param.t
 t/test_boilerplate.t
 t/testdata/reallylongdirectoryname/arch1/Config.pm
 t/testdata/reallylongdirectoryname/arch2/Config.pm

--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -37,7 +37,7 @@ our @ISA = qw(Exporter);
 our @EXPORT    = qw(&WriteMakefile $Verbose &prompt &os_unsupported);
 our @EXPORT_OK = qw($VERSION &neatvalue &mkbootstrap &mksymlists
                     &WriteEmptyMakefile &open_for_writing &write_file_via_tmp
-                    &_sprintf562);
+                    &_sprintf562 &supports_param);
 
 # These will go away once the last of the Win32 & VMS specific code is
 # purged.
@@ -1377,6 +1377,10 @@ EOF
         grep !$self->{SKIPHASH}{$_},
         qw(static dynamic config);
     join "\n", @m;
+}
+
+sub supports_param {
+    exists $Recognized_Att_Keys{$_[0]}
 }
 
 1;
@@ -3302,7 +3306,24 @@ The C<os_unsupported()> function provides a way to correctly exit your
 C<Makefile.PL> before calling C<WriteMakefile>. It is essentially a
 C<die> with the message "OS unsupported".
 
-This is supported since 7.26
+This is supported since 7.26.
+
+=item supports_param
+
+  use ExtUtils::MakeMaker 'supports_param'; # not exported by default
+  $supports_it = supports_param($param);
+
+  WriteMakefile(
+      supports_param('MIN_PERL_VERSION')
+        ? (MIN_PERL_VERSION => ...)
+        : (),
+      ...
+  );
+
+The C<supports_param()> function provides a way to probe the parameters
+that C<WriteMakefile> supports, without having to do version checks.
+
+This is supported since 7.32.
 
 =back
 

--- a/t/supports_param.t
+++ b/t/supports_param.t
@@ -1,0 +1,48 @@
+#!/usr/bin/perl -w
+
+# This script tests ExtUtils::MakeMaker::supports_param().
+
+use strict;
+use Test::More;
+
+# We don’t need to test all parameters; just enough to verify that the
+# mechanism is working.  This list is somewhat random, but it works.
+
+my @supported = qw(
+ ABSTRACT_FROM
+ AUTHOR
+ BUILD_REQUIRES
+ clean
+ dist
+ DISTNAME
+ DISTVNAME
+ LIBS
+ MAN3PODS
+ META_MERGE
+ MIN_PERL_VERSION
+ NAME
+ PL_FILES
+ PREREQ_PM
+ VERSION
+ VERSION_FROM
+);
+
+my @unsupported = qw(
+ WIBBLE
+ wump
+);
+
+plan tests => 2*(@supported+@unsupported);
+
+use ExtUtils::MakeMaker 'supports_param';
+
+for (@supported) {
+    ok supports_param($_), "EUMM supports param '$_' (exported func)";
+    ok ExtUtils::MakeMaker::supports_param($_), "EUMM supports param '$_'";
+}
+for (@unsupported) {
+    ok !supports_param($_),
+        "EUMM does not support param '$_' (exported func)";
+    ok !ExtUtils::MakeMaker::supports_param($_),
+        "EUMM does not support param '$_'";
+}


### PR DESCRIPTION
It is getting quite common these days to fill Makefiles.PL with version checks, because ExtUtils::MakeMaker provides no other way to probe its functionality.  This is something I will not do, because I think it’s crazy.  My approaches tend to be more draconian: <https://metacpan.org/source/SPROUT/Acme-Eatemup-0.02/Makefile.PL>.

Of course, ideally, instead of working around the lack of the feature, I should be a good citizen and propose a new feature to fill the gap.  So here is a patch that implements `supports_param`, which can be used by future Makefiles.PL (when EUMM 7.32 is standard) to probe for features, instead of looking at the version number.