### PR TITLE
Darwin: Recognize WriteMakefile(LIBS=>'-F path/'

### DIFF
--- a/lib/ExtUtils/Liblist/Kid.pm
+++ b/lib/ExtUtils/Liblist/Kid.pm
@@ -58,8 +58,9 @@ sub _unix_os2_ext {
     my ( $found ) = 0;
 
     if ( $^O eq 'darwin' or $^O eq 'next' )  {
-        # 'escape' Mach-O ld -framework flags, so they aren't dropped later on
+        # 'escape' Mach-O ld -framework and -F flags, so they aren't dropped later on
         $potential_libs =~ s/(^|\s)(-(?:weak_|reexport_|lazy_)?framework)\s+(\S+)/$1-Wl,$2 -Wl,$3/g;
+        $potential_libs =~ s/(^|\s)(-F)\s*(\S+)/$1-Wl,$2 -Wl,$3/g;
     }
 
     foreach my $thislib ( split ' ', $potential_libs ) {


### PR DESCRIPTION
`-F` is to `-framework` as `-L` is to `-l`. Commit 81c19c0f introduced in #309 support for
passing `-framework` to ld(1) on NeXTSTEP and Darwin, but `-F` support was missing.

Previously, these were dropped with an `'Unrecognized argument in LIBS ignored'`
warning. They are now 'escaped' with `-Wl,` so they may reach the linker.

macOS man page: http://www.unix.com/man-page/osx/1/ld/
NeXT man page: http://www.polarhome.com/service/man/?qf=ld&af=0&sf=0&of=NeXTSTEP&tf=2

[Live action demo](https://github.com/athreef/Graphics-Raylib/tree/EU-MM-F-demo/XS): Current EU::MM drops the `-F` on macOS (says `Unrecognized argument in LIBS ignored: '-F/System/Library/Frameworks'`). The attached patch fixes that.