### PR TITLE
Allow specifying extra inputs for PL_FILES scripts

### DIFF
--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -2599,6 +2599,20 @@ In this case the program will be run multiple times using each target file.
     perl bin/foobar.PL bin/foobar1
     perl bin/foobar.PL bin/foobar2
 
+If an output file depends on extra input files beside the script itself,
+a hash ref can be used in version 7.36 and above:
+
+    PL_FILES => { 'foo.PL' => {
+        'foo.out' => 'foo.in',
+        'bar.out' => [qw(bar1.in bar2.in)],
+    }
+
+In this case the extra input files will be passed to the program after
+the target file:
+
+   perl foo.PL foo.out foo.in
+   perl foo.PL bar.out bar1.in bar2.in
+
 PL files are normally run B<after> pm_to_blib and include INST_LIB and
 INST_ARCH in their C<@INC>, so the just built modules can be
 accessed... unless the PL file is making a module (or anything else in

--- a/t/PL_FILES.t
+++ b/t/PL_FILES.t
@@ -13,7 +13,7 @@ use ExtUtils::MM;
 use Test::More
     !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
     ? (skip_all => "cross-compiling and make not available")
-    : (tests => 10);
+    : (tests => 12);
 use File::Spec;
 use File::Temp qw[tempdir];
 use File::Path;
@@ -36,6 +36,8 @@ WriteMakefile(
     NAME     => 'PL::Module',
     PL_FILES => { 'single.PL' => 'single.out',
                   'multi.PL'  => [qw(1.out 2.out)],
+                  'single-in.PL' => { 'single-in.out' => 'single.in' },
+                  'multi-in.PL ' => { 'multi-in.out'  => [qw(1.in 2.in)] },
                   'Bar_pm.PL' => '$(INST_LIB)/PL/Bar.pm',
                   'Bar2.pm.PL' => 'Bar2.pm',
     },
@@ -53,6 +55,11 @@ END
     'multi.PL'         => _gen_pl_files(),
     'Bar_pm.PL'        => _gen_pm_files(),
     'Bar2.pm.PL'       => _gen_pm_files(),
+    'single-in.PL'     => _gen_pm_files(1),
+    'multi-in.PL'      => _gen_pm_files(2),
+    'single.in'        => '',
+    '1.in'             => '',
+    '2.in'             => '',
     'lib/PL/Foo.pm' => <<'END',
 # Module to load to ensure PL_FILES have blib in @INC.
 package PL::Foo;
@@ -76,7 +83,11 @@ cmp_ok( $?, '==', 0 );
 my $make_out = run("$make");
 is( $?, 0 ) || diag $make_out;
 
-foreach my $file (qw(single.out 1.out 2.out blib/lib/PL/Bar.pm blib/lib/PL/Bar2.pm)) {
+foreach my $file (qw(
+    single.out 1.out 2.out
+    single-in.out multi-in.out
+    blib/lib/PL/Bar.pm blib/lib/PL/Bar2.pm
+)) {
     ok( -e $file, "$file was created" );
 }
 
@@ -105,7 +116,8 @@ END
 }
 
 sub _gen_pm_files {
-    my $test = <<'END';
+    my $inputs = (shift || 0) + 1;
+    my $test = sprintf <<'END', $inputs;
 #!/usr/bin/perl -w
 
 # Ensure we do NOT have blib in @INC when building a module
@@ -114,7 +126,7 @@ eval { require PL::Foo; };
 
 # Had a bug where PL_FILES weren't sent the file to generate
 die "argv empty\n" unless @ARGV;
-die "too many in argv: @ARGV\n" unless @ARGV == 1;
+die "wrong number in argv: @ARGV\n" unless @ARGV == %d;
 
 my $file = $ARGV[0];
 open OUT, ">$file" or die $!;


### PR DESCRIPTION
The extra inputs are added as dependencies to the Makefile target, and
passed to the script after the target file name.