### PR TITLE
Win32 quote_literal needs to quote # because gmake 4.2.1

### DIFF
--- a/lib/ExtUtils/MM_Win32.pm
+++ b/lib/ExtUtils/MM_Win32.pm
@@ -506,7 +506,7 @@ sub quote_literal {
     $text =~ s{\\\\"}{\\\\\\\\\\"}g;  # \\" -> \\\\\"
     $text =~ s{(?<!\\)\\"}{\\\\\\"}g; # \"  -> \\\"
     $text =~ s{(?<!\\)"}{\\"}g;       # "   -> \"
-    $text = qq{"$text"} if $text =~ /[ \t]/;
+    $text = qq{"$text"} if $text =~ /[ \t#]/; # hash because gmake 4.2.1
 
     # Apply the Command Prompt parsing rules (cmd.exe)
     my @text = split /("[^"]*")/, $text;


### PR DESCRIPTION
This is needed due to https://rt.cpan.org/Ticket/Display.html?id=125173