### PR TITLE
add Visual C parallel building support

### DIFF
--- a/lib/ExtUtils/MM_Win32.pm
+++ b/lib/ExtUtils/MM_Win32.pm
@@ -595,6 +595,16 @@ sub os_flavor {
     return('Win32');
 }
 
+=item dbgoutflag
+
+Returns a CC flag that tells the CC to emit a separate debugging symbol file
+when compiling an object file.
+
+=cut
+
+sub dbgoutflag {
+    $MSVC ? '-Fd$(*).pdb' : '';
+}
 
 =item cflags
 


### PR DESCRIPTION
Win32 Visual C perl always generates symbol files for all binaries. These
have a name pattern of "vXX0.pdb". XX is the version number of Visual
Studio. It will be 6 through 14. When parallel building, with "gmake -j2"
or "dmake -P2", for a XS module that has multiple .obj files, 2 or more
cl.exe processes will execute simultaneously, and both will try to lock
vXX0.pdb and one of them will fatally error stopping the build of the
module.

Make the code have an API that if someone wants to, they can implement
GCC or other CCs "strip" debugging symbols into separate files from the
executable.

Example of cl.exe fatal error.

cl -c  -I. -nologo -GF -W3 -O1 -MD -Zi -DNDEBUG -GL -DWIN32 -D_CONSOLE
-DNO_STRICT -DPERL_TEXTMODE_SCRIPTS -DPERL_IMPLICIT_CONTEXT
-DPERL_IMPLICIT_SYS -DWIN32_NO_REGISTRY -DUSE_PERLIO -D_USE_32BIT_TIME_T
-O1 -MD -Zi -DNDEBUG -GL   -DVERSION=\"2.074\" -DXS_VERSION=\"2.074\"
"-I..\..\lib\CORE"  -DBZ_NO_STDIO  Bzip2.c
Bzip2.c
C:\perl521\srcnew\miniperl.exe "-I..\..\lib" -MExtUtils::Command::MM -e
cp_nonempty -- Bzip2.bs ..\..\lib\auto\Compress\Raw\Bzip2\Bzip2.bs 644
cl -c  -I. -nologo -GF -W3 -O1 -MD -Zi -DNDEBUG -GL -DWIN32 -D_CONSOLE
-DNO_STRICT -DPERL_TEXTMODE_SCRIPTS -DPERL_IMPLICIT_CONTEXT
-DPERL_IMPLICIT_SYS -DWIN32_NO_REGISTRY -DUSE_PERLIO -D_USE_32BIT_TIME_T
-O1 -MD -Zi -DNDEBUG -GL   -DVERSION=\"2.074\" -DXS_VERSION=\"2.074\"
"-I..\..\lib\CORE"  -DBZ_NO_STDIO  compress.c
compress.c
compress.c(0) : fatal error C1033: cannot open program database
'c:\perl527\src\cpan\compress-raw-bzip2\vc70.pdb'