### PR TITLE
ExtUtils::MM_Win32.pm: fix \ not replaced with .

### DIFF
--- a/lib/ExtUtils/MM_Win32.pm
+++ b/lib/ExtUtils/MM_Win32.pm
@@ -77,7 +77,7 @@ Changes the path separator with .
 
 sub replace_manpage_separator {
     my($self,$man) = @_;
-    $man =~ s,/+,.,g;
+    $man =~ s,[/\\]+,.,g;
     $man;
 }
 


### PR DESCRIPTION
As discussed on IRC, manpage file paths are not created correctly on Windows for some modules. For example with `File::Next` you get the following error when building the `manifypods`target:

```
Can't write-open blib\man3\File\Next.3pm: No such file or directory at C:/msys64/mingw64/lib/perl5/vendor_perl/ExtUtils/Command/MM.pm line 153.
```

Replacing backslash as well as forward slash with dot fixes the issue.