### PR TITLE
Avoid mangling /bin non-perl shebangs on merged-/usr systems

### DIFF
--- a/t/fixin.t
+++ b/t/fixin.t
@@ -9,7 +9,7 @@ BEGIN {
 
 use File::Spec;
 
-use Test::More tests => 22;
+use Test::More tests => 30;
 
 use Config;
 use TieOut;
@@ -122,4 +122,35 @@ blah blah blah
 END
         }
     );
+}
+
+SKIP: {
+    eval { chmod(0755, "usrbin/interp") }
+        or skip "no chmod", 8;
+
+    my $dir = getcwd();
+    local $ENV{PATH} = join $Config{path_sep}, map "$dir/$_", qw(usrbin bin);
+
+    test_fixin(<<END,
+#!$dir/bin/interp
+
+blah blah blah
+END
+         sub {
+             is $_[0], "#!$dir/usrbin/interp\n", 'interpreter updated to one found in PATH';
+         }
+     );
+
+    eval { symlink("../usrbin/interp", "bin/interp") }
+        or skip "no symlinks", 4;
+
+    test_fixin(<<END,
+#!$dir/bin/interp
+
+blah blah blah
+END
+         sub {
+             is $_[0], "#!$dir/bin/interp\n", 'symlinked interpreter later in PATH not mangled';
+         }
+     );
 }

--- a/t/lib/MakeMaker/Test/Setup/BFD.pm
+++ b/t/lib/MakeMaker/Test/Setup/BFD.pm
@@ -54,6 +54,9 @@ program - this is a program
 
 1;
 END
+             'Big-Dummy/usrbin/interp'       => <<'END',
+This is a dummy interpreter
+END
 
              'Big-Dummy/test.pl'          => <<'END',
 print "1..1\n";


### PR DESCRIPTION
If the shebang is absolute and exists in PATH, but was not the first
one found, leave it alone if it's actually the same file as first one.

This avoids packages built on merged-/usr systems with /usr/bin before
/bin in the path breaking when installed on systems without merged
/usr.  See e.g. https://bugs.debian.org/913637.