### PR TITLE
propagate all variables used by Buildroot

### DIFF
--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -702,7 +702,8 @@ END
         }
         if ($self->{PARENT}) {
             $self->{PARENT}->{CHILDREN}->{$newclass} = $self;
-            foreach my $opt (qw(POLLUTE PERL_CORE LINKTYPE LD OPTIMIZE)) {
+            foreach my $opt (qw(POLLUTE PERL_CORE LINKTYPE AR FULL_AR CC CCFLAGS
+                                OPTIMIZE LD LDDLFLAGS LDFLAGS PERL_ARCHLIB DESTDIR)) {
                 if (exists $self->{PARENT}->{$opt}
                     and not exists $self->{$opt})
                     {


### PR DESCRIPTION
In Buildroot, these variables are set in order to cross compile a module.
When there are Makefile.PL in subdirectories, EU::MM must propagate them.

See how Buildroot does it : https://git.busybox.net/buildroot/tree/package/pkg-perl.mk?id=da9e06cabc578bf9138e100d1492a2d5f2038415#n96

Note: Debian asks same thing in https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/commit/98e8532fffe5afa8186329acc44fb957427f1823