### PR TITLE
Add.appveyor+fixes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,173 @@
+# .appveyor.yml (for Perl distributions)
+
+# * (APIv1) for usage instructions, see <https://github.com/rivy/CI.AppVeyor.helpers-perl/blob/stable.APIv1/README.mkd>
+
+# ref: <https://www.appveyor.com/docs/appveyor-yml>[`@`](https://archive.is/OUJHS)
+# * "appveyor.yml" validation tool @ <https://ci.appveyor.com/tools/validate-yaml>
+
+version: "{build} ~ {branch}"
+
+branches:
+  except:
+    - gh-pages
+
+skip_tags: true     ## do not build on tags
+
+matrix:
+  allow_failures:
+    - AUTHOR_TESTING: 1
+    - TEST_SIGNATURE: 1
+    - CI_HELPER_BRANCH: canary
+    - Perl_VERSION: "5.8.8" ## allow perl v5.8.8 failures; (v5.8.8 is problematic for many projects)
+
+environment:
+  matrix:
+    - Perl_VERSION: "latest"
+      COVERAGE: "Codecov Coveralls" ## note: case sensitive!
+      AUTHOR_TESTING: 1
+      RELEASE_TESTING: 1
+    - Perl_VERSION: "5.28"
+    - Perl_VERSION: "5.26"
+    - Perl_VERSION: "5.24"
+    - Perl_VERSION: "5.22"
+    - Perl_VERSION: "5.20"
+    - Perl_VERSION: "5.16"
+    - Perl_VERSION: "5.14"
+    - Perl_VERSION: "5.12"
+    - Perl_VERSION: "5.10"
+    - Perl_VERSION: "5.8.9"
+    - Perl_VERSION: "5.8.8"
+    - Perl_VERSION: "latest"
+      CI_HELPER_BRANCH: "canary"
+      TEST_SIGNATURE: 1
+  global:
+    AUTOMATED_TESTING: 1
+    CI_CACHE_DIR: "C:\\cache"
+    #
+    # debug?
+    # CI_DEBUG: 1               ##  [ "" == false, <non-empty> == true ]; "true" enables detailed output for the helper scripts
+    #
+    ## configuration (CI/network-side settings and then ".appveyor_init.{BAT,PS1}" [if present], may override these values [by design])
+    ## ---
+    # * standard perl distribution test configuration signals
+    AUTHOR_TESTING: ""
+    RELEASE_TESTING: ""
+    # * .appveyor.yml configuration variables
+    CI_HELPER_API_VERSION: "1"  ## * API version (the expected/requested helper API version)
+    CI_HELPER_BRANCH: ""        ## "" => auto-set, valid alternates are [ "stable" (the default), "canary", BRANCH, or TAG ]
+    CI_HELPER_REPO: ""          ## "" => auto-set; allows easier use of alternate helper scripts (ie, alternate forks)
+    DEVEL_COVER_OPTIONS: ""     ## "" => auto-set, value determined by DIST_TOOLING; quoted whitespace (eg, " ") is an empty/neutral setting which also blocks auto-set
+    DIST_EXTRA_DEPS: ""         ## additional required/requested dependencies for build and/or testing
+    DIST_SUPPRESS_DEPS: ""      ## [ "" == false, <non-empty> == true ]; "true" can be useful for CORE modules, suppressing discovery and installation of dependencies, unless otherwise required (by COVERAGE or DIST_EXTRA_DEPS)
+    DIST_TOOLING: ""            ## [ "build", "make" ]; "" => auto-set based on existence of "Build.PL" and/or "Makefile.PL"
+    TEST_METHOD: ""             ## "" => auto-set based on DIST_TOOLING (`perl Build test`, `%make% test`, or `prove -bl`)
+    TEST_FILES: ""              ## "" => auto-set to "" for build/make distributions, otherwise "t" or "t xt" depending on AUTHOR_TESTING and/or RELEASE_TESTING and directory existence
+    ## ---
+
+cache:
+# note: unused, because, unfortunately, the available cache is too small to be helpful (unshared; 1GB across all projects)
+#   - '%CI_CACHE_DIR% -> .appveyor.yml'
+
+install:
+  - ps: ; write-host $("[{0:HH:mm:ss}].install" -f $($mark = get-date; $mark)) -f darkgray
+  # ensure CWD is project main directory
+  - cd "%APPVEYOR_BUILD_FOLDER%"
+  # perform any special preparation (optional; distribution specific)
+  # * note: optional external file(s), global scope => allows ".appveyor.yml" to remain more stable and similar [or the same] between different distributions [eg, for automated distribution of ".appveyor.yml" changes]
+  - if EXIST ".appveyor_init.BAT" ( call .appveyor_init.BAT )
+  - ps: if ( test-path ".appveyor_init.PS1" ) { . ".\.appveyor_init.PS1" }
+  # save current-point-in-time environment (for later logging of environment variable overrides)
+  - ps: $baseline_env = @(get-childitem env:)
+  # create a working area
+  - ps: if ( ! $env:CI_TEMP_DIR ) { $env:CI_TEMP_DIR = "${env:TEMP}\${env:APPVEYOR_JOB_ID}" ; mkdir -force $env:CI_TEMP_DIR | out-null }
+  # create cache area, if missing
+  - if NOT DEFINED CI_CACHE_DIR ( set "CI_CACHE_DIR=%CI_TEMP_DIR%\cache" )
+  - if NOT EXIST "%CI_CACHE_DIR%" ( mkdir "%CI_CACHE_DIR%" )
+  # finalize HELPER repository location
+  - if NOT DEFINED CI_HELPER_API_VERSION ( set "CI_HELPER_API_VERSION=1" )
+  - if NOT DEFINED CI_HELPER_REPO ( set "CI_HELPER_REPO=https://github.com/rivy/CI.AppVeyor.helpers-perl.git" )
+  - if NOT DEFINED CI_HELPER_BRANCH ( set "CI_HELPER_BRANCH=stable" )
+  - if /i "%CI_HELPER_BRANCH%"=="canary" ( set "CI_HELPER_BRANCH=canary.APIv%CI_HELPER_API_VERSION%" )
+  - if /i "%CI_HELPER_BRANCH%"=="stable" ( set "CI_HELPER_BRANCH=stable.APIv%CI_HELPER_API_VERSION%" )
+  # find / download helpers
+  - ps: ; write-host $("[{0:HH:mm:ss}].install (helpers)" -f $($mark_sub = get-date; $mark_sub)) -f darkgray
+  # * use "vendored" copy if present
+  - ps: if ( ! $env:CI_HELPERS -and (test-path ".appveyor_bin") ) { $env:CI_HELPERS=[IO.Path]::GetFullPath(".appveyor_bin") ; ${env:CI_HELPER_REPO} = ${env:APPVEYOR_REPO_NAME} ; ${env:CI_HELPER_BRANCH_DESC} = ${env:APPVEYOR_REPO_COMMIT} ; }
+  # * clone/download helpers from HELPER repo (via `git`) if needed
+  - ps: if ( ! $env:CI_HELPERS ) { $repo_path = $( mkdir "${env:CI_TEMP_DIR}\helpers" ).Fullname ; $git_cmd = "git clone ${env:CI_HELPER_REPO} `"${repo_path}`" -b ${env:CI_HELPER_BRANCH} 2>&1" ; write-host "[``${git_cmd}``]" ; & 'CMD' @( '/c', $git_cmd ) ; $err = $LASTEXITCODE ; $env:CI_HELPERS = "${repo_path}\.appveyor_bin" ; if ($err -ne 0) { exit $err } ; }
+  - ps: if ( ! $env:CI_HELPER_BRANCH_DESC ) { ${env:CI_HELPER_BRANCH_DESC} = $( pushd "${env:CI_HELPERS}" ; & 'git' @( 'describe', '--always' ) 2>&1 ; popd ) ; }
+  - ps: ; write-host $("[{0:HH:mm:ss}].install (helpers) ... (${env:CI_HELPER_REPO}@${env:CI_HELPER_BRANCH_DESC})")
+  # resolve requested coverage with needed configuration
+  - ps: . "${env:CI_HELPERS}\#install.determine-coverage.PS1"
+  ##
+  # highlight any overrides within baseline environment
+  - ps: $baseline_env | & "${env:CI_HELPERS}\log.env-overrides.PS1"
+  ##
+  # move "C:\mingw" to avoid cross library linking (a problem with older perl versions, breaking dll compilation with "/mingw/lib/dllcrt2.o:(.text+0xd1): undefined reference to `__dyn_tls_init_callback'")
+  # * only truly needed for modules containing XS compilation, but ok for all modules
+  - move c:\mingw c:\mingw.o >NUL
+  # force branch checkout (if knowable), then reset to the specific commit ## (needed for accurate code coverage info)
+  # * this allows later apps to see the branch name using standard `git branch` operations, yet always builds the correct specific commit
+  # * ref: <https://github.com/appveyor/ci/issues/1606>[`@`](https://archive.is/RVpnF)
+  - if DEFINED APPVEYOR_REPO_BRANCH if /i "%APPVEYOR_REPO_SCM%"=="git" ( git checkout "%APPVEYOR_REPO_BRANCH%" >NUL & git reset --hard "%APPVEYOR_REPO_COMMIT%" )
+  # install perl (strawberry variant) + version verification
+  - ps: ; write-host $("[{0:HH:mm:ss}].install (perl)" -f $($mark_sub = get-date; $mark_sub)) -f darkgray
+  - ps: . "${env:CI_HELPERS}\#install.install-perl.PS1"
+  - perl -V
+  - ps: ; write-host $("[{0:HH:mm:ss}].install (perl) ... done ({1:0.0}s)" -f $(get-date; $($(get-date) - $mark_sub).totalseconds)) -f gray
+  # determine build tooling
+  - ps: . "${env:CI_HELPERS}\#install.determine-tooling.PS1"
+  # setup DEVEL_COVER_OPTIONS, if needed
+  - ps: if (! $env:DEVEL_COVER_OPTIONS) { . "${env:CI_HELPERS}\#install.setup-cover_options.PS1" }
+  # setup testing method/options and test files
+  - ps: . "${env:CI_HELPERS}\#install.setup-testing.PS1"
+  # distribution prep prior to the build/make process (ie, build dependencies and OS_unsupported check)
+  - ps: ; write-host $("[{0:HH:mm:ss}].install (distribution requirements and recommendations)" -f $($mark_sub = get-date; $mark_sub)) -f darkgray
+  - ps: . "${env:CI_HELPERS}\#install.setup-dist.PS1"
+  - ps: ; write-host $("[{0:HH:mm:ss}].install (distribution requirements and recommendations) ... done ({1:0.0}s)" -f $(get-date; $($(get-date) - $mark_sub).totalseconds)) -f gray
+  # coverage prep
+  - ps: ; write-host $("[{0:HH:mm:ss}].install (coverage requirements)" -f $($mark_sub = get-date; $mark_sub)) -f darkgray
+  - ps: . "${env:CI_HELPERS}\#install.setup-coverage.PS1"
+  - ps: ; write-host $("[{0:HH:mm:ss}].install (coverage requirements) ... done ({1:0.0}s)" -f $(get-date; $($(get-date) - $mark_sub).totalseconds)) -f gray
+  #
+  - ps: ; write-host $("[{0:HH:mm:ss}].install ... done ({1:0.0}s)" -f $(get-date; $($(get-date) - $mark).totalseconds)) -f green
+
+before_build:
+  - ps: ; write-host $("[{0:HH:mm:ss}].build.before_build" -f $($mark = get-date; $mark)) -f darkgray
+  # ensure CWD is project main directory
+  - cd "%APPVEYOR_BUILD_FOLDER%"
+  # * for non-COVERAGE builds, enable parallel processing (COVERAGE builds need sequential, correctly interleaved, output to avoid warnings)
+  - if NOT DEFINED COVERAGE (set "HARNESS_OPTIONS=j")
+  - set HARNESS_TIMER=1
+  # * for COVERAGE builds, enable coverage for `prove` testing
+  - if DEFINED COVERAGE (set HARNESS_PERL_SWITCHES=-MDevel::Cover %HARNESS_PERL_SWITCHES%)
+  # * for COVERAGE builds, preload JSON:PP to avoid JSON::PP::Boolean redefine warning (see <https://github.com/rurban/Cpanel-JSON-XS/issues/65#issuecomment-219352754>)
+  - if DEFINED COVERAGE (set HARNESS_PERL_SWITCHES=-MJSON::PP %HARNESS_PERL_SWITCHES%)
+  #
+  - ps: . "${env:CI_HELPERS}\#build-before_build.PS1"
+  # show final build-related environment variables
+  - ps: . "${env:CI_HELPERS}\log.env.PS1"
+  #
+  - ps: ; write-host $("[{0:HH:mm:ss}].build.before_build ... done ({1:0.0}s)" -f $(get-date; $($(get-date) - $mark).totalseconds)) -f green
+
+build_script:
+  - ps: ; write-host $("[{0:HH:mm:ss}].build.build_script" -f $($mark = get-date; $mark)) -f darkgray
+  - ps: . "${env:CI_HELPERS}\#build-build_script.PS1"
+  - ps: ; write-host $("[{0:HH:mm:ss}].build.build_script ... done ({1:0.0}s)" -f $(get-date; $($(get-date) - $mark).totalseconds)) -f green
+
+test_script:
+  - ps: ; write-host $("[{0:HH:mm:ss}].test.test_script" -f $($mark = get-date; $mark)) -f darkgray
+  - ps: . "${env:CI_HELPERS}\#test-test_script.PS1"
+  - ps: ; write-host $("[{0:HH:mm:ss}].test.test_script ... done ({1:0.0}s)" -f $(get-date; $($(get-date) - $mark).totalseconds)) -f green
+
+after_test:
+  - ps: ; write-host $("[{0:HH:mm:ss}].test.after_test" -f $($mark = get-date; $mark)) -f darkgray
+  # reporting
+  # * report any code coverage information
+  - ps: if (-not $env:OS_unsupported -and $env:COVERAGE) { $env:COVERAGE.split() | foreach { & 'CMD' @( '/c', "cover -report $_ 2>&1" ) } }
+  - ps: ; write-host $("[{0:HH:mm:ss}].test.after_test ... done ({1:0.0}s)" -f $(get-date; $($(get-date) - $mark).totalseconds)) -f green
+  # end with any informational or warning messages, if needed
+  - ps: if ($env:CI_SKIP) { write-host -f magenta "info:` CI_SKIP enabled" ; Add-AppveyorMessage -Message "CI_SKIP enabled" -Category Info }
+  - ps: if ($env:CI_SKIP_TEST) { write-host -f magenta "info:` CI_SKIP_TEST enabled" ; Add-AppveyorMessage -Message "CI_SKIP_TEST enabled" -Category Info }
+  # * prominent "unsupported" warning
+  - ps: if ($env:OS_unsupported) { write-host -f magenta "WARN:` OS unsupported" ; Add-AppveyorMessage -Message "OS unsupported" -Category Warning }

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -139,8 +139,9 @@ BIN_WARN
     }
 
     sub special_targets {
-      my $make_frag = shift->SUPER::special_targets(@_);
-      return $make_frag if $Is_VMS; # not supported in MMS, MMK
+      my ( $self ) = shift;
+      my $make_frag = $self->SUPER::special_targets(@_);
+      return $make_frag if $Is_VMS or $self->is_make_type('dmake'); # not supported in MMS, MMK or by `dmake`
       $make_frag .= <<'MAKE_FRAG';
 .NOTPARALLEL: pure_all
 

--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -1103,7 +1103,6 @@ Finds the executables PERL and FULLPERL
 
 sub find_perl {
     my($self, $ver, $names, $dirs, $trace) = @_;
-
     if ($trace >= 2){
         print "Looking for perl $ver by these names:
 @$names
@@ -2077,6 +2076,11 @@ sub init_PERL {
     # already escaped spaces.
     $self->{FULLPERL} =~ tr/"//d if $Is{VMS};
 
+    # `dmake` can fail for image (aka, executable) names which start with double-quotes
+    # * push quote inward by at least one character (or the drive prefix, if present)
+    # * including any initial directory separator preserves the `file_name_is_absolute` property
+    $self->{FULLPERL} =~ s/^"(\S(:\\|:)?)/$1"/ if $self->is_make_type('dmake');
+
     # Little hack to get around VMS's find_perl putting "MCR" in front
     # sometimes.
     $self->{ABSPERL} = $self->{PERL};
@@ -2098,6 +2102,11 @@ sub init_PERL {
     # Can't have an image name with quotes, and findperl will have
     # already escaped spaces.
     $self->{PERL} =~ tr/"//d if $Is{VMS};
+
+    # `dmake` can fail for image (aka, executable) names which start with double-quotes
+    # * push quote inward by at least one character (or the drive prefix, if present)
+    # * including any initial directory separator preserves the `file_name_is_absolute` property
+    $self->{PERL} =~ s/^"(\S(:\\|:)?)/$1"/ if $self->is_make_type('dmake');
 
     # Are we building the core?
     $self->{PERL_CORE} = $ENV{PERL_CORE} unless exists $self->{PERL_CORE};

--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -693,6 +693,7 @@ END
             } else {
                 my $value = $self->{$key};
                 # not going to test in FS so only stripping start
+                $value =~ s/"// if $key =~ /PERL$/ and $self->is_make_type('dmake');
                 $value =~ s/^"// if $key =~ /PERL$/;
                 $value = $self->catdir("..", $value)
                   unless $self->file_name_is_absolute($value);

--- a/lib/ExtUtils/MakeMaker/Locale.pm
+++ b/lib/ExtUtils/MakeMaker/Locale.pm
@@ -99,6 +99,13 @@ sub _init {
 	$ENCODING_LOCALE ||= $ENCODING_CONSOLE_IN;
     }
 
+    # Workaround of Encode < v2.71 for "cp65000" and "cp65001"
+    # The "cp65000" and "cp65001" aliases were added in [Encode v2.71](https://github.com/dankogai/p5-encode/commit/7874bd95aa10967a3b5dbae333d16bcd703ac6c6)
+    # via commit <https://github.com/dankogai/p5-encode/commit/84b9c1101d5251d37e226f80d1c6781718779047>.
+    # This will avoid test failures for Win32 machines using the UTF-7 or UTF-8 code pages.
+    $ENCODING_LOCALE = 'UTF-7' if lc($ENCODING_LOCALE) eq "cp65000";
+    $ENCODING_LOCALE = 'utf-8-strict' if lc($ENCODING_LOCALE) eq "cp65001";
+
     if ($^O eq "darwin") {
 	$ENCODING_LOCALE_FS ||= "UTF-8";
     }

--- a/lib/ExtUtils/MakeMaker/Locale.pm
+++ b/lib/ExtUtils/MakeMaker/Locale.pm
@@ -47,7 +47,10 @@ sub _init {
             unless (defined &GetInputCP) {
                 eval {
                     require Win32;
-                    eval { Win32::GetConsoleCP() };
+                    eval {
+                        local $SIG{__WARN__} = sub {} if ( "$]" < 5.014 ); # suppress deprecation warning for inherited AUTOLOAD of Win32::GetConsoleCP()
+                        Win32::GetConsoleCP();
+                    };
                     # manually "import" it since Win32->import refuses
                     *GetInputCP = sub { &Win32::GetConsoleCP } if defined &Win32::GetConsoleCP;
                     *GetOutputCP = sub { &Win32::GetConsoleOutputCP } if defined &Win32::GetConsoleOutputCP;

--- a/t/basic.t
+++ b/t/basic.t
@@ -35,7 +35,11 @@ my $Is_VMS = $^O eq 'VMS';
 my $OLD_CP; # crude but...
 my $w32worked; # or whether we had to fallback to chcp
 if ($^O eq "MSWin32") {
-    eval { require Win32; $w32worked = $OLD_CP = Win32::GetConsoleCP() };
+    eval {
+        require Win32;
+        local $SIG{__WARN__} = sub {} if ( "$]" < 5.014 ); # suppress deprecation warning for inherited AUTOLOAD of Win32::GetConsoleCP()
+        $w32worked = $OLD_CP = Win32::GetConsoleCP();
+    };
     $OLD_CP = $1 if !$w32worked and qx(chcp) =~ /(\d+)$/ and $? == 0;
     if (defined $OLD_CP) {
         if ($w32worked) {

--- a/t/parse_version.t
+++ b/t/parse_version.t
@@ -110,7 +110,7 @@ our $VERSION = 2.34;
 END
 }
 
-if ( "$]" > 5.009 && "$]" < 5.012 ) {
+if ( "$]" < 5.012 ) {
   delete $versions{'$VERSION = -1.0'};
 }
 


### PR DESCRIPTION
EU:MM has been broken on MSWin32 with early versions of perl (specifically Strawberry Perl < v5.14) for quite some time:

- for perl versions < 5.14, installing ExtUtils::MakeMaker >= 7.0 causes ... "The system cannot find the path specified.\ndmake.exe:  Error code 129, while making 'blib\lib\ExtUtils\.exists'"
- for perl versions = 5.12, installing ExtUtils::MakeMaker >= 7.0 causes ... "Use of inherited AUTOLOAD for non-method Win32::GetConsoleCP() is deprecated at C:/strawberry/perl/site/lib/ExtUtils/MakeMaker/Locale.pm line 50."
- for perl versions <= 5.10, installing ExtUtils::MakeMaker < 6.98 or >= 7.0 causes various odd failures (eg, "! Installing ExtUtils::MakeMaker failed. ... Retry with --force to force install it.").

For perl versions > 5.24, the default make type was changed to `gmake` and ExtUtils::MakeMaker works without issue.

I created an improved AppVeyor CI config (in the spirit of @haarg's Travis CI toolset) which I've been testing and using for a while and now I'm slowly releasing it into more public use. The supplied AppVeyor config (and related helper tools) is able to test all the way back to Perl v5.8.8.8 (the earliest Strawberry Perl available). Further information about the AppVeyor CI config is available at [rivy/CI.AppVeyor.helpers-perl](https://github.com/rivy/CI.AppVeyor.helpers-perl/blob/master/README.mkd).

I wanted to get EU:MM working back that far as well (see failures on report at [AppVeyor CI/add.appveyor](https://ci.appveyor.com/project/rivy/perl-extutils-makemaker/builds/18502150)). So, I created this PR which includes that AppVeyor CI (for testing) along with several annotated commits that fix all the MSWin32-related problems.

The PR compiles successfully all the way back to Perl v5.8.8.8 for MSWin32/AppVeyor and Perl v5.6.2 for Travis (see reports at [AppVeyor CI](https://ci.appveyor.com/project/rivy/perl-extutils-makemaker/builds/22425643) and [Travis CI](https://travis-ci.org/rivy/perl.ExtUtils-MakeMaker/builds/494315234)). It also includes support for code coverage (see reports at [CodeCov](https://codecov.io/gh/rivy/perl.ExtUtils-MakeMaker/branch/add.appveyor%2Bfixes) and [Coveralls](https://coveralls.io/github/rivy/perl.ExtUtils-MakeMaker)).

I know it's a relatively large set of changes, but I've the segregated the changes into fairly small, mentally digestible components.

I hope this is acceptable, and let me know if you'd like any changes.