### PR TITLE
stringify version before comparing, as recommended by Zefram

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -30,7 +30,7 @@ if( $BUILDING_AS_PACKAGE ) {
         'ExtUtils::Manifest'       => '1.70',
         'version'                  => '0',
     );
-    $Extra_Prereqs{'JSON::PP::Compat5006'} = '1.09' if $] < 5.008;
+    $Extra_Prereqs{'JSON::PP::Compat5006'} = '1.09' if "$]" < 5.008;
 
     %Extra_Test_Prereqs = (
         'File::Temp'               => '0.22',
@@ -65,7 +65,7 @@ my $MM = WriteMakefile(
         'Pod::Man'       => 0,                 # manifypods needs Pod::Man
         'File::Basename' => 0,
         'Data::Dumper'   => 0,
-        ($] > 5.008 ? (Encode => 0) : ()),
+        ("$]" > 5.008 ? (Encode => 0) : ()),
     },
     TEST_REQUIRES    => \%Extra_Test_Prereqs,
 
@@ -92,7 +92,7 @@ my $MM = WriteMakefile(
 
     CONFIGURE_REQUIRES => {},                  # We don't need ourself to install ourself.
     BUILD_REQUIRES     => {},                  # We don't need ourself to build ourself.
-    INSTALLDIRS        => ( $] < 5.012 ? 'perl' : 'site' ),
+    INSTALLDIRS        => ( "$]" < 5.012 ? 'perl' : 'site' ),
     LICENSE            => 'perl',
     AUTHOR             => 'Michael G Schwern <schwern@pobox.com>',
 

--- a/lib/ExtUtils/MM_Any.pm
+++ b/lib/ExtUtils/MM_Any.pm
@@ -1090,7 +1090,7 @@ END
     my @man_cmds;
     foreach my $section (qw(1 3)) {
         my $pods = $self->{"MAN${section}PODS"};
-        my $p2m = sprintf <<'CMD', $section, $] > 5.008 ? " -u" : "";
+        my $p2m = sprintf <<'CMD', $section, "$]" > 5.008 ? " -u" : "";
 	$(NOECHO) $(POD2MAN) --section=%s --perm_rw=$(PERM_RW)%s
 CMD
         push @man_cmds, $self->split_command($p2m, map {($_,$pods->{$_})} sort keys %$pods);

--- a/lib/ExtUtils/MM_Cygwin.pm
+++ b/lib/ExtUtils/MM_Cygwin.pm
@@ -86,7 +86,7 @@ sub init_linker {
 
     if ($Config{useshrplib} eq 'true') {
         my $libperl = '$(PERL_INC)' .'/'. "$Config{libperl}";
-        if( $] >= 5.006002 ) {
+        if( "$]" >= 5.006002 ) {
             $libperl =~ s/(dll\.)?a$/dll.a/;
         }
         $self->{PERL_ARCHIVE} = $libperl;

--- a/lib/ExtUtils/MM_NW5.pm
+++ b/lib/ExtUtils/MM_NW5.pm
@@ -192,7 +192,7 @@ MAKE_FRAG
     }
     # Reconstruct the X.Y.Z version.
     my $version = join '.', map { sprintf "%d", $_ }
-                              $] =~ /(\d)\.(\d{3})(\d{2})/;
+                              "$]" =~ /(\d)\.(\d{3})(\d{2})/;
     push @m, sprintf <<'EOF', $from, $version, $to, $exportlist;
 	$(LD) $(LDFLAGS) %s -desc "Perl %s Extension ($(BASEEXT))  XS_VERSION: $(XS_VERSION)" -nlmversion $(NLM_VERSION) -o %s $(MYEXTLIB) $(PERL_INC)\Main.lib -commandfile %s
 	$(CHMOD) 755 $@

--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -2906,7 +2906,7 @@ sub parse_abstract {
     }
     close $fh;
 
-    if ( $pod_encoding and !( $] < 5.008 or !$Config{useperlio} ) ) {
+    if ( $pod_encoding and !( "$]" < 5.008 or !$Config{useperlio} ) ) {
         # Have to wrap in an eval{} for when running under PERL_CORE
         # Encode isn't available during build phase and parsing
         # ABSTRACT isn't important there
@@ -3185,7 +3185,7 @@ PPD_PERLVERS
     }
 
     my $archname = $Config{archname};
-    if ($] >= 5.008) {
+    if ("$]" >= 5.008) {
         # archname did not change from 5.6 to 5.8, but those versions may
         # not be not binary compatible so now we append the part of the
         # version that changes when binary compatibility may change

--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -398,7 +398,7 @@ sub full_setup {
           );
 
     # 5.5.3 doesn't have any concept of vendor libs
-    push @Get_from_Config, qw( vendorarchexp vendorlibexp ) if $] >= 5.006;
+    push @Get_from_Config, qw( vendorarchexp vendorlibexp ) if "$]" >= 5.006;
 
     foreach my $item (@attrib_help){
         $Recognized_Att_Keys{$item} = 1;
@@ -534,7 +534,7 @@ sub new {
             # simulate "use warnings FATAL => 'all'" for vintage perls
             die @_;
         };
-        !$self->{MIN_PERL_VERSION} or $self->{MIN_PERL_VERSION} <= $]
+        !$self->{MIN_PERL_VERSION} or $self->{MIN_PERL_VERSION} <= "$]"
     };
     if (!$perl_version_ok) {
         if (!defined $perl_version_ok) {
@@ -1265,7 +1265,7 @@ sub write_file_via_tmp {
     die "write_file_via_tmp: 2nd arg must be ref" unless ref $contents;
     for my $chunk (@$contents) {
         my $to_write = $chunk;
-        utf8::encode $to_write if !$CAN_DECODE && $] > 5.008;
+        utf8::encode $to_write if !$CAN_DECODE && "$]" > 5.008;
         print $fh "$to_write\n" or die "Can't write to MakeMaker.tmp: $!";
     }
     close $fh or die "Can't write to MakeMaker.tmp: $!";

--- a/lib/ExtUtils/MakeMaker/version.pm
+++ b/lib/ExtUtils/MakeMaker/version.pm
@@ -35,7 +35,7 @@ $CLASS = 'version';
         *version::_VERSION = \&ExtUtils::MakeMaker::version::vpp::_VERSION;
         *version::vcmp = \&ExtUtils::MakeMaker::version::vpp::vcmp;
         *version::new = \&ExtUtils::MakeMaker::version::vpp::new;
-        if ($] >= 5.009000) {
+        if ("$]" >= 5.009000) {
             no strict 'refs';
             *version::stringify = \&ExtUtils::MakeMaker::version::vpp::stringify;
             *{'version::(""'} = \&ExtUtils::MakeMaker::version::vpp::stringify;

--- a/lib/ExtUtils/MakeMaker/version/vpp.pm
+++ b/lib/ExtUtils/MakeMaker/version/vpp.pm
@@ -934,11 +934,11 @@ sub _un_vstring {
     if ( length($value) >= 3 && $value !~ /[._]/
 	&& _is_non_alphanumeric($value)) {
 	my $tvalue;
-	if ( $] ge 5.008_001 ) {
+	if ( "$]" >= 5.008_001 ) {
 	    $tvalue = _find_magic_vstring($value);
 	    $value = $tvalue if length $tvalue;
 	}
-	elsif ( $] ge 5.006_000 ) {
+	elsif ( "$]" >= 5.006_000 ) {
 	    $tvalue = sprintf("v%vd",$value);
 	    if ( $tvalue =~ /^v\d+(\.\d+){2,}$/ ) {
 		# must be a v-string
@@ -973,7 +973,7 @@ sub _VERSION {
     my $class = ref($obj) || $obj;
 
     no strict 'refs';
-    if ( exists $INC{"$class.pm"} and not %{"$class\::"} and $] >= 5.008) {
+    if ( exists $INC{"$class.pm"} and not %{"$class\::"} and "$]" >= 5.008) {
 	 # file but no package
 	require Carp;
 	Carp::croak( "$class defines neither package nor VERSION"
@@ -982,14 +982,14 @@ sub _VERSION {
 
     my $version = eval "\$$class\::VERSION";
     if ( defined $version ) {
-	local $^W if $] <= 5.008;
+	local $^W if "$]" <= 5.008;
 	$version = ExtUtils::MakeMaker::version::vpp->new($version);
     }
 
     if ( defined $req ) {
 	unless ( defined $version ) {
 	    require Carp;
-	    my $msg =  $] < 5.006
+	    my $msg = "$]" < 5.006
 	    ? "$class version $req required--this is only version "
 	    : "$class does not define \$$class\::VERSION"
 	      ."--version check failed";

--- a/lib/ExtUtils/Mksymlists.pm
+++ b/lib/ExtUtils/Mksymlists.pm
@@ -148,7 +148,7 @@ sub _write_win32 {
     # linked to directly from C. GSAR 97-07-10
 
     #bcc dropped in 5.16, so dont create useless extra symbols for export table
-    unless($] >= 5.016) {
+    unless("$]" >= 5.016) {
         if ($Config::Config{'cc'} =~ /^bcc/i) {
             push @syms, "_$_", "$_ = _$_"
                 for (@{$data->{DL_VARS}}, @{$data->{FUNCLIST}});

--- a/my/bundles.pm
+++ b/my/bundles.pm
@@ -46,7 +46,7 @@ my %special_dist = (
     },
     "cpan-meta" => sub {
         # Only for perls > 5.008
-        return if $] < 5.008;
+        return if "$]" < 5.008;
         &should_use_dist;
     },
 );
@@ -153,7 +153,7 @@ package my::bundles::Copy::Recursive;
 use strict;
 BEGIN {
     # Keep older versions of Perl from trying to use lexical warnings
-    $INC{'warnings.pm'} = "fake warnings entry for < 5.6 perl ($])" if $] < 5.006;
+    $INC{'warnings.pm'} = "fake warnings entry for < 5.6 perl ($])" if "$]" < 5.006;
 }
 use warnings;
 
@@ -371,7 +371,7 @@ sub dircopy {
 
       
       my @files;
-      if ( $] < 5.006 ) {
+      if ( "$]" < 5.006 ) {
           opendir(STR_DH, $str) or return;
           @files = grep( $_ ne '.' && $_ ne '..', readdir(STR_DH));
           closedir STR_DH;
@@ -461,7 +461,7 @@ sub pathempty {
 
    my @names;
    my $pth_dh;
-   if ( $] < 5.006 ) {
+   if ( "$]" < 5.006 ) {
        opendir(PTH_DH, $pth) or return;
        @names = grep !/^\.+$/, readdir(PTH_DH);
    }
@@ -485,7 +485,7 @@ sub pathempty {
       }
    }
 
-   if ( $] < 5.006 ) {
+   if ( "$]" < 5.006 ) {
        closedir PTH_DH;
    }
    else {

--- a/t/MM_Cygwin.t
+++ b/t/MM_Cygwin.t
@@ -80,7 +80,7 @@ like( $res, qr/manifypods.*foo.*foo.1/s, '... should add MAN3PODS targets' );
 # init_linker
 {
     my $libperl = $Config{libperl} || 'libperl.a';
-    $libperl =~ s/\.a/.dll.a/ if $] >= 5.006002;
+    $libperl =~ s/\.a/.dll.a/ if "$]" >= 5.006002;
     $libperl = "\$(PERL_INC)/$libperl";
 
     my $export  = '';

--- a/t/basic.t
+++ b/t/basic.t
@@ -128,7 +128,7 @@ like( $ppd_html, qr{^\s*<REQUIRE NAME="strict::" />}m,  '  <REQUIRE>' );
 unlike( $ppd_html, qr{^\s*<REQUIRE NAME="warnings::" />}m,  'no <REQUIRE> for build_require' );
 
 my $archname = $Config{archname};
-if( $] >= 5.008 ) {
+if( "$]" >= 5.008 ) {
     # XXX This is a copy of the internal logic, so it's not a great test
     $archname .= "-$Config{PERL_REVISION}.$Config{PERL_VERSION}";
 }

--- a/t/lib/MakeMaker/Test/Utils.pm
+++ b/t/lib/MakeMaker/Test/Utils.pm
@@ -407,7 +407,7 @@ sub hash2files {
         $file = File::Spec->catfile(File::Spec->curdir, $prefix, split m{\/}, $file);
         my $dir = dirname($file);
         mkpath $dir;
-        my $utf8 = ($] < 5.008 or !$Config{useperlio}) ? "" : ":utf8";
+        my $utf8 = ("$]" < 5.008 or !$Config{useperlio}) ? "" : ":utf8";
         open(FILE, ">$utf8", $file) || die "Can't create $file: $!";
         print FILE $text;
         close FILE;

--- a/t/lib/Test/Builder.pm
+++ b/t/lib/Test/Builder.pm
@@ -8,7 +8,7 @@ our $VERSION = '0.99';
 $VERSION = eval $VERSION;    ## no critic (BuiltinFunctions::ProhibitStringyEval)
 
 BEGIN {
-    if( $] < 5.008 ) {
+    if( "$]" < 5.008 ) {
         require Test::Builder::IO::Scalar;
     }
 }
@@ -19,7 +19,7 @@ BEGIN {
     use Config;
     # Load threads::shared when threads are turned on.
     # 5.8.0's threads are so busted we no longer support them.
-    if( $] >= 5.008001 && $Config{useithreads} && $INC{'threads.pm'} ) {
+    if( "$]" >= 5.008001 && $Config{useithreads} && $INC{'threads.pm'} ) {
         require threads::shared;
 
         # Hack around YET ANOTHER threads::shared bug.  It would
@@ -1891,7 +1891,7 @@ sub _new_fh {
     }
     elsif( ref $file_or_fh eq 'SCALAR' ) {
         # Scalar refs as filehandles was added in 5.8.
-        if( $] >= 5.008 ) {
+        if( "$]" >= 5.008 ) {
             open $fh, ">>", $file_or_fh
               or $self->croak("Can't open scalar ref $file_or_fh: $!");
         }

--- a/t/parse_version.t
+++ b/t/parse_version.t
@@ -53,7 +53,7 @@ if( $Has_Version ) {
     $versions{q[$VERSION = v1.2.3]} = 'v1.2.3';
 }
 
-if( $] >= 5.011001 ) {
+if( "$]" >= 5.011001 ) {
     $versions{'package Foo 1.23;'         } = '1.23';
     $versions{'package Foo::Bar 1.23;'    } = '1.23';
     $versions{'package Foo v1.2.3;'       } = 'v1.2.3';
@@ -81,7 +81,7 @@ our $VERSION = 2.34;
 END
 }
 
-if( $] >= 5.014 ) {
+if( "$]" >= 5.014 ) {
     $versions{'package Foo 1.23 { }'         } = '1.23';
     $versions{'package Foo::Bar 1.23 { }'    } = '1.23';
     $versions{'package Foo v1.2.3 { }'       } = 'v1.2.3';
@@ -110,7 +110,7 @@ our $VERSION = 2.34;
 END
 }
 
-if ( $] > 5.009 && $] < 5.012 ) {
+if ( "$]" > 5.009 && "$]" < 5.012 ) {
   delete $versions{'$VERSION = -1.0'};
 }
 

--- a/t/unicode.t
+++ b/t/unicode.t
@@ -14,7 +14,7 @@ use File::Path;
 use utf8;
 BEGIN {
   plan skip_all => 'Need perlio and perl 5.8+.'
-    if $] < 5.008 or !$Config{useperlio};
+    if "$]" < 5.008 or !$Config{useperlio};
   plan skip_all => 'cross-compiling and make not available'
     if !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'};
 
@@ -76,7 +76,7 @@ END {
 ok( chdir $DIRNAME, "chdir'd to $DIRNAME" ) ||
   diag("chdir failed: $!");
 
-if ($] >= 5.008) {
+if ("$]" >= 5.008) {
   eval { require ExtUtils::MakeMaker::Locale; };
   note "ExtUtils::MakeMaker::Locale vars: $ExtUtils::MakeMaker::Locale::ENCODING_LOCALE;$ExtUtils::MakeMaker::Locale::ENCODING_LOCALE_FS;$ExtUtils::MakeMaker::Locale::ENCODING_CONSOLE_IN;$ExtUtils::MakeMaker::Locale::ENCODING_CONSOLE_OUT\n" unless $@;
   note "Locale env vars: " . join(';', map {

--- a/t/vstrings.t
+++ b/t/vstrings.t
@@ -93,7 +93,7 @@ sub run_test {
   local $_;
   SKIP: {
     skip "No vstring test <5.8", 2
-      if $] < 5.008 && $pkg eq 'BareV2String' && $descrip =~ m!^2-part!;
+      if "$]" < 5.008 && $pkg eq 'BareV2String' && $descrip =~ m!^2-part!;
     my $warnings;
     eval { $warnings = capture_make("Fake::$pkg" => $version); };
     is($@, '', "$descrip not fatal") or skip "$descrip WM failed", 1;


### PR DESCRIPTION
To avoid floating point errors, `$]` should be stringified first, and then compared numerically against the static version.