### PR TITLE
Honour man page disablement under INSTALL_BASE

### DIFF
--- a/lib/ExtUtils/MM_Any.pm
+++ b/lib/ExtUtils/MM_Any.pm
@@ -2214,7 +2214,9 @@ sub init_INSTALL_from_INSTALL_BASE {
             my $key = "INSTALL".$dir.$uc_thing;
 
             $install{$key} ||=
-              $self->catdir('$(INSTALL_BASE)', @{$map{$thing}});
+                ($thing =~ /^man.dir$/ and not $Config{lc $key})
+                ? 'none'
+                : $self->catdir('$(INSTALL_BASE)', @{$map{$thing}});
         }
     }
 


### PR DESCRIPTION
Whe perl is built with -Dman[13]dir=none, the corresponding
man pages should not be built or installed.

The init_INSTALL_from_INSTALL_BASE method was setting
INSTALL(SITE|VENDOR)?MAN[13]DIR to '$(INSTALL_BASE)/man/man[13]'
unconditionally.  Set them to 'none' if the corresponding %Config
variable is empty.

This fixes https://rt.cpan.org/Ticket/Display.html?id=114644