### PR TITLE
Empty elements in @d make mod2fname return a bogus name

### DIFF
--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -968,6 +968,7 @@ sub dynamic_lib {
             my ($v, $d, $f) = File::Spec->splitpath($ext);
             my @d = File::Spec->splitdir($d);
             shift @d if $d[0] eq 'lib';
+            pop @d if $d[$#d] eq '';
             my $instdir = $self->catdir('$(INST_ARCHLIB)', 'auto', @d, $f);
 
             # Dynamic library names may need special handling.
@@ -2227,6 +2228,7 @@ sub init_xs {
 		my ($v, $d, $f) = File::Spec->splitpath($ext);
 		my @d = File::Spec->splitdir($d);
 		shift @d if defined $d[0] and $d[0] eq 'lib';
+        pop @d if $d[$#d] eq '';
 		my $instdir = $self->catdir('$(INST_ARCHLIB)', 'auto', @d, $f);
 		my $instfile = $self->catfile($instdir, $f);
 		push @statics, "$instfile\$(LIB_EXT)";

--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -2228,7 +2228,7 @@ sub init_xs {
 		my ($v, $d, $f) = File::Spec->splitpath($ext);
 		my @d = File::Spec->splitdir($d);
 		shift @d if defined $d[0] and $d[0] eq 'lib';
-        pop @d if $d[$#d] eq '';
+		pop @d if $d[$#d] eq '';
 		my $instdir = $self->catdir('$(INST_ARCHLIB)', 'auto', @d, $f);
 		my $instfile = $self->catfile($instdir, $f);
 		push @statics, "$instfile\$(LIB_EXT)";


### PR DESCRIPTION
There seems to be a bug in MM_Unix.pm which is manifesting on Android builds during "make test" in ./cpan/ExtUtils-MakeMaker/t/02-xsdynamic.t.  The problem boils down to EUMM creating libs with names like PL_XS____Test.so whilst DynaLoader looks for PL_XS__Test.so.

Note: On regular *nix builds, mod2fname is not built by DynaLoader_pm.PL, so they don't encounter this problem. (Thanks to haarg on IRC for explaining that to me.)

Working backwards, when DynaLoader.pm wants to bootstrap something like XS::Test, to figure out the .so name, it does the following:
(Note, line numbers from DynaLoader_pm.PL in blead today)
````
 320     my @modparts = split(/::/,$module);
 321     my $modfname = $modparts[-1];
 322     my $modfname_orig = $modfname; # For .bs file search
 323 
 324     # Some systems have restrictions on files names for DLL's etc.
 325     # mod2fname returns appropriate file base name (typically truncated)
 326     # It may also edit @modparts if required.
 327     $modfname = &mod2fname(\@modparts) if defined &mod2fname;
````
So it's calling DynaLoader::mod2fname with \('XS,'Test')

The important bits of mod2fname are:
````
 245 sub mod2fname {
 246     my $parts = shift;
 247     my $so_len = %d;
 248     my $name_max = 255; # No easy way to get this here
 249     
 250     my $libname = "PL_" .  join("__", @$parts);
````
So mod2fname is going to return "PL_XS__Test" as the name of the .so to load.

In ExtUtils/MM_Unix.pm, when ($self->{XSMULTI}) is true and DynaLoader::mod2fname is defined, mod2fname is used to determine what the name of the .so to create will be. The calls to mod2fname in dynamic_lib() and init_xs() set up their arguments like this:

````2168                 my ($v, $d, $f) = File::Spec->splitpath($ext);````

$ext is something like 'lib/XS/Test'
.. resulting in:
$v contains an empty string
$d contains 'lib/XS/'
$f contains 'Test'

````2169                 my @d = File::Spec->splitdir($d);````

@d initially contains:
````
'$VAR1 = [
#           'lib',
#           'XS',
#           ''
#         ];
````
````2170                 shift @d if defined $d[0] and $d[0] eq 'lib';````

@d then contains:
````
'$VAR1 = [
#           'XS',
#           ''
#         ];
````
...
````2179                     $dynfile = $self->catfile($instdir, &DynaLoader::mod2fname([@d, $f]));````

So the filename returned by mod2fname is "PL_" .  join("__", ('XS','','Test') ) because of the empty array element, hence four underscores in the filename when DynaLoader is going to expect only two.

This pull request pops off the empty array element in @d, which resolves the test failures locally.