### PR TITLE
Guess man section from man*dir

### DIFF
--- a/lib/ExtUtils/MM_Any.pm
+++ b/lib/ExtUtils/MM_Any.pm
@@ -1088,9 +1088,9 @@ manifypods : pure_all config $dependencies
 END
 
     my @man_cmds;
-    foreach my $section (qw(1 3)) {
-        my $pods = $self->{"MAN${section}PODS"};
-        my $p2m = sprintf <<'CMD', $section, "$]" > 5.008 ? " -u" : "";
+    foreach my $num (qw(1 3)) {
+        my $pods = $self->{"MAN${num}PODS"};
+        my $p2m = sprintf <<'CMD', "\$(MAN${num}SECTION)", "$]" > 5.008 ? " -u" : "";
 	$(NOECHO) $(POD2MAN) --section=%s --perm_rw=$(PERM_RW)%s
 CMD
         push @man_cmds, $self->split_command($p2m, map {($_,$pods->{$_})} sort keys %$pods);

--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -419,6 +419,7 @@ sub constants {
               INST_ARCHLIB INST_SCRIPT INST_BIN INST_LIB
               INST_MAN1DIR INST_MAN3DIR
               MAN1EXT      MAN3EXT
+              MAN1SECTION  MAN3SECTION
               INSTALLDIRS INSTALL_BASE DESTDIR PREFIX
               PERLPREFIX      SITEPREFIX      VENDORPREFIX
                    ),
@@ -1499,6 +1500,24 @@ sub init_MANPODS {
             my $init_method = "init_${man}PODS";
             $self->$init_method();
         }
+    }
+
+    # logic similar to picking man${num}ext in perl's Configure script
+    foreach my $num (1,3) {
+        my $installdirs = uc $self->{INSTALLDIRS};
+        $installdirs = '' if $installdirs eq 'PERL';
+        my $mandir = $self->_expand_macros(
+            $self->{ "INSTALL${installdirs}MAN${num}DIR" } );
+        my $section = $num;
+
+        foreach ($num, "${num}p", "${num}pm", qw< l n o C L >, "L$num") {
+            if ( $mandir =~ /\b(?:man|cat)$_$/ ) {
+                $section = $_;
+                last;
+            }
+        }
+
+        $self->{"MAN${num}SECTION"} = $section;
     }
 }
 


### PR DESCRIPTION
In OpenBSD we put perl module man pages into the "3p" section, but MM only knows to tell `pod2man` about section 1 or 3, not the actual section where they live.  This PR will attempt to detect the section based on the "install${INSTALLDIRS}man[13]dir", similar to what is done to detect the "man?ext" in perl's Configure script.

I'm not sure what limitations there are with this being a core module that is included with perl, but am open to suggestions.