### PR TITLE
Fix test warnings

### DIFF
--- a/t/MM_Unix.t
+++ b/t/MM_Unix.t
@@ -12,7 +12,7 @@ BEGIN {
         plan skip_all => 'Non-Unix platform';
     }
     else {
-        plan tests => 113;
+        plan tests => 114;
     }
 }
 
@@ -152,9 +152,15 @@ is ($t->has_link_code(),1); is ($t->{HAS_LINK_CODE},1);
 
 {
     # suppress noisy & unnecessary "WARNING: Older versions of ExtUtils::MakeMaker may errantly install README.pod..."
-    local $SIG{__WARN__} = sub { };
+    my @warnings = ();
+    local $SIG{__WARN__} = sub { push @warnings, shift; };
     is ($t->libscan('Readme.pod'),      '', 'libscan excludes base Readme.pod');
     is ($t->libscan('README.pod'),      '', 'libscan excludes base README.pod');
+    # verify that suppressed warnings are present
+    isnt (scalar(@warnings), 0);
+    if (scalar(@warnings)) {
+        note (sprintf('suppressed warnings: [ "%s" ]', do { my $s = join(q/" , "/, @warnings); $s =~ s/([^[:print:]])/sprintf('\x{%x}', ord($1))/egmsx; $s; }));
+    }
 }
 is ($t->libscan('lib/Foo/README.pod'),      'lib/Foo/README.pod', 'libscan accepts README.pod in a subdirectory');
 is ($t->libscan('foo/RCS/bar'),     '', 'libscan on RCS');

--- a/t/MM_Unix.t
+++ b/t/MM_Unix.t
@@ -150,8 +150,12 @@ is ($t->has_link_code(),1); is ($t->{HAS_LINK_CODE},1);
 ###############################################################################
 # libscan
 
-is ($t->libscan('Readme.pod'),      '', 'libscan excludes base Readme.pod');
-is ($t->libscan('README.pod'),      '', 'libscan excludes base README.pod');
+{
+    # suppress noisy & unnecessary "WARNING: Older versions of ExtUtils::MakeMaker may errantly install README.pod..."
+    local $SIG{__WARN__} = sub { };
+    is ($t->libscan('Readme.pod'),      '', 'libscan excludes base Readme.pod');
+    is ($t->libscan('README.pod'),      '', 'libscan excludes base README.pod');
+}
 is ($t->libscan('lib/Foo/README.pod'),      'lib/Foo/README.pod', 'libscan accepts README.pod in a subdirectory');
 is ($t->libscan('foo/RCS/bar'),     '', 'libscan on RCS');
 is ($t->libscan('CVS/bar/car'),     '', 'libscan on CVS');

--- a/t/build_man.t
+++ b/t/build_man.t
@@ -44,10 +44,15 @@ ok((my $stdout = tie *STDOUT, 'TieOut'), 'tie stdout');
 
 {
     local $Config{installman3dir} = File::Spec->catdir(qw(t lib));
-    my $mm = WriteMakefile(
-        NAME            => 'Big::Dummy',
-        VERSION_FROM    => 'lib/Big/Dummy.pm',
-    );
+    my $mm;
+    {
+        # suppress noisy & unnecessary "WARNING: Older versions of ExtUtils::MakeMaker may errantly install README.pod..."
+        local $SIG{__WARN__} = sub { };
+        $mm = WriteMakefile(
+            NAME            => 'Big::Dummy',
+            VERSION_FROM    => 'lib/Big/Dummy.pm',
+        );
+    }
     my %got = %{ $mm->{MAN3PODS} };
     # because value too OS-specific
     my $delete_key = $^O eq 'VMS' ? '[.lib.Big]Dummy.pm' : 'lib/Big/Dummy.pm';
@@ -56,29 +61,44 @@ ok((my $stdout = tie *STDOUT, 'TieOut'), 'tie stdout');
 }
 
 {
-    my $mm = WriteMakefile(
-        NAME            => 'Big::Dummy',
-        VERSION_FROM    => 'lib/Big/Dummy.pm',
-        INSTALLMAN3DIR  => 'none'
-    );
+    my $mm;
+    {
+        # suppress noisy & unnecessary "WARNING: Older versions of ExtUtils::MakeMaker may errantly install README.pod..."
+        local $SIG{__WARN__} = sub { };
+        $mm = WriteMakefile(
+            NAME            => 'Big::Dummy',
+            VERSION_FROM    => 'lib/Big/Dummy.pm',
+            INSTALLMAN3DIR  => 'none'
+        );
+    }
     is_deeply $mm->{MAN3PODS}, {}, 'suppress man3pod with "none"';
 }
 
 {
-    my $mm = WriteMakefile(
-        NAME            => 'Big::Dummy',
-        VERSION_FROM    => 'lib/Big/Dummy.pm',
-        MAN3PODS        => {}
-    );
+    my $mm;
+    {
+        # suppress noisy & unnecessary "WARNING: Older versions of ExtUtils::MakeMaker may errantly install README.pod..."
+        local $SIG{__WARN__} = sub { };
+        $mm = WriteMakefile(
+            NAME            => 'Big::Dummy',
+            VERSION_FROM    => 'lib/Big/Dummy.pm',
+            MAN3PODS        => {}
+        );
+    }
     is_deeply $mm->{MAN3PODS}, {}, 'suppress man3pod with {}';
 }
 
 {
-    my $mm = WriteMakefile(
-        NAME            => 'Big::Dummy',
-        VERSION_FROM    => 'lib/Big/Dummy.pm',
-        MAN3PODS        => { "Foo.pm" => "Foo.1" }
-    );
+    my $mm;
+    {
+        # suppress noisy & unnecessary "WARNING: Older versions of ExtUtils::MakeMaker may errantly install README.pod..."
+        local $SIG{__WARN__} = sub { };
+        $mm = WriteMakefile(
+            NAME            => 'Big::Dummy',
+            VERSION_FROM    => 'lib/Big/Dummy.pm',
+            MAN3PODS        => { "Foo.pm" => "Foo.1" }
+        );
+    }
     is_deeply $mm->{MAN3PODS}, { "Foo.pm" => "Foo.1" }, 'override man3pod';
 }
 

--- a/t/build_man.t
+++ b/t/build_man.t
@@ -7,7 +7,7 @@ BEGIN {
 }
 
 use strict;
-use Test::More tests => 46;
+use Test::More tests => 50;
 
 use File::Spec;
 use File::Temp qw[tempdir];
@@ -47,11 +47,17 @@ ok((my $stdout = tie *STDOUT, 'TieOut'), 'tie stdout');
     my $mm;
     {
         # suppress noisy & unnecessary "WARNING: Older versions of ExtUtils::MakeMaker may errantly install README.pod..."
-        local $SIG{__WARN__} = sub { };
+        my @warnings = ();
+        local $SIG{__WARN__} = sub { push @warnings, shift; };
         $mm = WriteMakefile(
             NAME            => 'Big::Dummy',
             VERSION_FROM    => 'lib/Big/Dummy.pm',
         );
+        # verify that suppressed warnings are present
+        isnt (scalar(@warnings), 0);
+        if (scalar(@warnings)) {
+            note (sprintf('suppressed warnings: [ "%s" ]', do { my $s = join(q/" , "/, @warnings); $s =~ s/([^[:print:]])/sprintf('\x{%x}', ord($1))/egmsx; $s; }));
+        }
     }
     my %got = %{ $mm->{MAN3PODS} };
     # because value too OS-specific
@@ -64,12 +70,18 @@ ok((my $stdout = tie *STDOUT, 'TieOut'), 'tie stdout');
     my $mm;
     {
         # suppress noisy & unnecessary "WARNING: Older versions of ExtUtils::MakeMaker may errantly install README.pod..."
-        local $SIG{__WARN__} = sub { };
+        my @warnings = ();
+        local $SIG{__WARN__} = sub { push @warnings, shift; };
         $mm = WriteMakefile(
             NAME            => 'Big::Dummy',
             VERSION_FROM    => 'lib/Big/Dummy.pm',
             INSTALLMAN3DIR  => 'none'
         );
+        # verify that suppressed warnings are present
+        isnt (scalar(@warnings), 0);
+        if (scalar(@warnings)) {
+            note (sprintf('suppressed warnings: [ "%s" ]', do { my $s = join(q/" , "/, @warnings); $s =~ s/([^[:print:]])/sprintf('\x{%x}', ord($1))/egmsx; $s; }));
+        }
     }
     is_deeply $mm->{MAN3PODS}, {}, 'suppress man3pod with "none"';
 }
@@ -78,12 +90,18 @@ ok((my $stdout = tie *STDOUT, 'TieOut'), 'tie stdout');
     my $mm;
     {
         # suppress noisy & unnecessary "WARNING: Older versions of ExtUtils::MakeMaker may errantly install README.pod..."
-        local $SIG{__WARN__} = sub { };
+        my @warnings = ();
+        local $SIG{__WARN__} = sub { push @warnings, shift; };
         $mm = WriteMakefile(
             NAME            => 'Big::Dummy',
             VERSION_FROM    => 'lib/Big/Dummy.pm',
             MAN3PODS        => {}
         );
+        # verify that suppressed warnings are present
+        isnt (scalar(@warnings), 0);
+        if (scalar(@warnings)) {
+            note (sprintf('suppressed warnings: [ "%s" ]', do { my $s = join(q/" , "/, @warnings); $s =~ s/([^[:print:]])/sprintf('\x{%x}', ord($1))/egmsx; $s; }));
+        }
     }
     is_deeply $mm->{MAN3PODS}, {}, 'suppress man3pod with {}';
 }
@@ -92,12 +110,18 @@ ok((my $stdout = tie *STDOUT, 'TieOut'), 'tie stdout');
     my $mm;
     {
         # suppress noisy & unnecessary "WARNING: Older versions of ExtUtils::MakeMaker may errantly install README.pod..."
-        local $SIG{__WARN__} = sub { };
+        my @warnings = ();
+        local $SIG{__WARN__} = sub { push @warnings, shift; };
         $mm = WriteMakefile(
             NAME            => 'Big::Dummy',
             VERSION_FROM    => 'lib/Big/Dummy.pm',
             MAN3PODS        => { "Foo.pm" => "Foo.1" }
         );
+        # verify that suppressed warnings are present
+        isnt (scalar(@warnings), 0);
+        if (scalar(@warnings)) {
+            note (sprintf('suppressed warnings: [ "%s" ]', do { my $s = join(q/" , "/, @warnings); $s =~ s/([^[:print:]])/sprintf('\x{%x}', ord($1))/egmsx; $s; }));
+        }
     }
     is_deeply $mm->{MAN3PODS}, { "Foo.pm" => "Foo.1" }, 'override man3pod';
 }
@@ -203,4 +227,3 @@ unlink $README;
             "Set POD2MAN section to \$(MAN3SECTION)";
     }
 }
-

--- a/t/testrules.yml
+++ b/t/testrules.yml
@@ -1,0 +1,11 @@
+---
+# TAP::Harness test rules
+# "t\02-xsdynamic.t" (and possibly "t\03-xsstatic.t") should *not* be run in parallel
+# ... allowing overlap of these tests causes race conditions which lead to intermittent failures
+seq:
+  - seq:
+    # serialize all tests in files matching "t/0*.t"
+    - t{\\,/}0*.t
+  - par:
+    # run all other tests in parallel
+    - **


### PR DESCRIPTION
* fixes spurious and distracting warnings while testing on *nix and MSWin32
  - [AppVeyor CI test report](https://ci.appveyor.com/project/rivy/perl-extutils-makemaker/builds/27352019)
  - [Travis CI test report](https://travis-ci.org/rivy/perl.ExtUtils-MakeMaker/builds/583893461)