### PR TITLE
Add crosslinks to various referenced documentation

### DIFF
--- a/lib/ExtUtils/MM.pm
+++ b/lib/ExtUtils/MM.pm
@@ -23,9 +23,9 @@ ExtUtils::MM - OS adjusted ExtUtils::MakeMaker subclass
 
 B<FOR INTERNAL USE ONLY>
 
-ExtUtils::MM is a subclass of ExtUtils::MakeMaker which automatically
+ExtUtils::MM is a subclass of L<ExtUtils::MakeMaker> which automatically
 chooses the appropriate OS specific subclass for you
-(ie. ExtUils::MM_Unix, etc...).
+(ie. L<ExtUtils::MM_Unix>, etc...).
 
 It also provides a convenient alias via the MM class (I didn't want
 MakeMaker modules outside of ExtUtils/).

--- a/lib/ExtUtils/MM_AIX.pm
+++ b/lib/ExtUtils/MM_AIX.pm
@@ -19,10 +19,10 @@ ExtUtils::MM_AIX - AIX specific subclass of ExtUtils::MM_Unix
 
 =head1 DESCRIPTION
 
-This is a subclass of ExtUtils::MM_Unix which contains functionality for
+This is a subclass of L<ExtUtils::MM_Unix> which contains functionality for
 AIX.
 
-Unless otherwise stated it works just like ExtUtils::MM_Unix
+Unless otherwise stated it works just like ExtUtils::MM_Unix.
 
 =head2 Overridden methods
 

--- a/lib/ExtUtils/MM_Any.pm
+++ b/lib/ExtUtils/MM_Any.pm
@@ -46,7 +46,7 @@ ExtUtils::MM_Any is a superclass for the ExtUtils::MM_* set of
 modules.  It contains methods which are either inherently
 cross-platform or are written in a cross-platform manner.
 
-Subclass off of ExtUtils::MM_Any I<and> ExtUtils::MM_Unix.  This is a
+Subclass off of ExtUtils::MM_Any I<and> L<ExtUtils::MM_Unix>.  This is a
 temporary solution.
 
 B<THIS MAY BE TEMPORARY!>
@@ -1167,7 +1167,7 @@ MAKE_FRAG
 
     $mm->_fix_metadata_before_conversion( \%metadata );
 
-Fixes errors in the metadata before it's handed off to CPAN::Meta for
+Fixes errors in the metadata before it's handed off to L<CPAN::Meta> for
 conversion. This hopefully results in something that can be used further
 on, no guarantee is made though.
 
@@ -2418,7 +2418,7 @@ Initializes the macro definitions having to do with compiling and
 linking used by tools_other() and places them in the $MM object.
 
 If there is no description, its the same as the parameter to
-WriteMakefile() documented in ExtUtils::MakeMaker.
+WriteMakefile() documented in L<ExtUtils::MakeMaker>.
 
 =cut
 
@@ -2769,7 +2769,7 @@ END
 
 =head2 File::Spec wrappers
 
-ExtUtils::MM_Any is a subclass of File::Spec.  The methods noted here
+ExtUtils::MM_Any is a subclass of L<File::Spec>.  The methods noted here
 override File::Spec.
 
 

--- a/lib/ExtUtils/MM_BeOS.pm
+++ b/lib/ExtUtils/MM_BeOS.pm
@@ -12,7 +12,7 @@ ExtUtils::MM_BeOS - methods to override UN*X behaviour in ExtUtils::MakeMaker
 
 =head1 DESCRIPTION
 
-See ExtUtils::MM_Unix for a documentation of the methods provided
+See L<ExtUtils::MM_Unix> for a documentation of the methods provided
 there. This package overrides the implementation of these methods, not
 the semantics.
 

--- a/lib/ExtUtils/MM_Cygwin.pm
+++ b/lib/ExtUtils/MM_Cygwin.pm
@@ -22,7 +22,7 @@ ExtUtils::MM_Cygwin - methods to override UN*X behaviour in ExtUtils::MakeMaker
 
 =head1 DESCRIPTION
 
-See ExtUtils::MM_Unix for a documentation of the methods provided there.
+See L<ExtUtils::MM_Unix> for a documentation of the methods provided there.
 
 =over 4
 

--- a/lib/ExtUtils/MM_DOS.pm
+++ b/lib/ExtUtils/MM_DOS.pm
@@ -21,10 +21,10 @@ ExtUtils::MM_DOS - DOS specific subclass of ExtUtils::MM_Unix
 
 =head1 DESCRIPTION
 
-This is a subclass of ExtUtils::MM_Unix which contains functionality
+This is a subclass of L<ExtUtils::MM_Unix> which contains functionality
 for DOS.
 
-Unless otherwise stated, it works just like ExtUtils::MM_Unix
+Unless otherwise stated, it works just like ExtUtils::MM_Unix.
 
 =head2 Overridden methods
 

--- a/lib/ExtUtils/MM_Darwin.pm
+++ b/lib/ExtUtils/MM_Darwin.pm
@@ -21,7 +21,7 @@ ExtUtils::MM_Darwin - special behaviors for OS X
 
 =head1 DESCRIPTION
 
-See L<ExtUtils::MM_Unix> for L<ExtUtils::MM_Any> for documentation on the
+See L<ExtUtils::MM_Unix> or L<ExtUtils::MM_Any> for documentation on the
 methods overridden here.
 
 =head2 Overridden Methods

--- a/lib/ExtUtils/MM_NW5.pm
+++ b/lib/ExtUtils/MM_NW5.pm
@@ -10,7 +10,7 @@ ExtUtils::MM_NW5 - methods to override UN*X behaviour in ExtUtils::MakeMaker
 
 =head1 DESCRIPTION
 
-See ExtUtils::MM_Unix for a documentation of the methods provided
+See L<ExtUtils::MM_Unix> for a documentation of the methods provided
 there. This package overrides the implementation of these methods, not
 the semantics.
 

--- a/lib/ExtUtils/MM_OS2.pm
+++ b/lib/ExtUtils/MM_OS2.pm
@@ -24,7 +24,7 @@ ExtUtils::MM_OS2 - methods to override UN*X behaviour in ExtUtils::MakeMaker
 
 =head1 DESCRIPTION
 
-See ExtUtils::MM_Unix for a documentation of the methods provided
+See L<ExtUtils::MM_Unix> for a documentation of the methods provided
 there. This package overrides the implementation of these methods, not
 the semantics.
 

--- a/lib/ExtUtils/MM_QNX.pm
+++ b/lib/ExtUtils/MM_QNX.pm
@@ -19,10 +19,10 @@ ExtUtils::MM_QNX - QNX specific subclass of ExtUtils::MM_Unix
 
 =head1 DESCRIPTION
 
-This is a subclass of ExtUtils::MM_Unix which contains functionality for
+This is a subclass of L<ExtUtils::MM_Unix> which contains functionality for
 QNX.
 
-Unless otherwise stated it works just like ExtUtils::MM_Unix
+Unless otherwise stated it works just like ExtUtils::MM_Unix.
 
 =head2 Overridden methods
 

--- a/lib/ExtUtils/MM_UWIN.pm
+++ b/lib/ExtUtils/MM_UWIN.pm
@@ -19,10 +19,10 @@ ExtUtils::MM_UWIN - U/WIN specific subclass of ExtUtils::MM_Unix
 
 =head1 DESCRIPTION
 
-This is a subclass of ExtUtils::MM_Unix which contains functionality for
+This is a subclass of L<ExtUtils::MM_Unix> which contains functionality for
 the AT&T U/WIN UNIX on Windows environment.
 
-Unless otherwise stated it works just like ExtUtils::MM_Unix
+Unless otherwise stated it works just like ExtUtils::MM_Unix.
 
 =head2 Overridden methods
 

--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -63,10 +63,10 @@ ExtUtils::MM_Unix - methods used by ExtUtils::MakeMaker
 =head1 DESCRIPTION
 
 The methods provided by this package are designed to be used in
-conjunction with ExtUtils::MakeMaker. When MakeMaker writes a
+conjunction with L<ExtUtils::MakeMaker>. When MakeMaker writes a
 Makefile, it creates one or more objects that inherit their methods
-from a package C<MM>. MM itself doesn't provide any methods, but it
-ISA ExtUtils::MM_Unix class. The inheritance tree of MM lets operating
+from a package L<MM|ExtUtils::MM>. MM itself doesn't provide any methods, but
+it ISA ExtUtils::MM_Unix class. The inheritance tree of MM lets operating
 specific packages take the responsibility for all the methods provided
 by MM_Unix. We are trying to reduce the number of the necessary
 overrides by defining rather primitive operations within
@@ -93,8 +93,8 @@ Not all of the methods below are overridable in a
 Makefile.PL. Overridable methods are marked as (o). All methods are
 overridable by a platform specific MM_*.pm file.
 
-Cross-platform methods are being moved into MM_Any.  If you can't find
-something that used to be in here, look in MM_Any.
+Cross-platform methods are being moved into L<MM_Any|ExtUtils::MM_Any>.
+If you can't find something that used to be in here, look in MM_Any.
 
 =cut
 
@@ -3528,7 +3528,7 @@ sub escape_newlines {
 
 =item max_exec_len
 
-Using POSIX::ARG_MAX.  Otherwise falling back to 4096.
+Using L<POSIX>::ARG_MAX.  Otherwise falling back to 4096.
 
 =cut
 

--- a/lib/ExtUtils/MM_VMS.pm
+++ b/lib/ExtUtils/MM_VMS.pm
@@ -38,7 +38,7 @@ ExtUtils::MM_VMS - methods to override UN*X behaviour in ExtUtils::MakeMaker
 
 =head1 DESCRIPTION
 
-See ExtUtils::MM_Unix for a documentation of the methods provided
+See L<ExtUtils::MM_Unix> for a documentation of the methods provided
 there. This package overrides the implementation of these methods, not
 the semantics.
 
@@ -87,7 +87,7 @@ sub ext {
 Those methods which override default MM_Unix methods are marked
 "(override)", while methods unique to MM_VMS are marked "(specific)".
 For overridden methods, documentation is limited to an explanation
-of why this method overrides the MM_Unix method; see the ExtUtils::MM_Unix
+of why this method overrides the MM_Unix method; see the L<ExtUtils::MM_Unix>
 documentation for more details.
 
 =over 4
@@ -251,7 +251,8 @@ sub find_perl {
 
 =item _fixin_replace_shebang (override)
 
-Helper routine for MM->fixin(), overridden because there's no such thing as an
+Helper routine for L<< MM->fixin()|ExtUtils::MM_Unix/fixin >>, overridden
+because there's no such thing as an
 actual shebang line that will be interpreted by the shell, so we just prepend
 $Config{startperl} and preserve the shebang line argument for any switches it
 may contain.
@@ -1488,8 +1489,8 @@ uninstall_from_vendordirs ::
 =item perldepend (override)
 
 Use VMS-style syntax for files; it's cheaper to just do it directly here
-than to have the MM_Unix method call C<catfile> repeatedly.  Also, if
-we have to rebuild Config.pm, use MM[SK] to do it.
+than to have the L<MM_Unix|ExtUtils::MM_Unix> method call C<catfile>
+repeatedly.  Also, if we have to rebuild Config.pm, use MM[SK] to do it.
 
 =cut
 
@@ -2082,7 +2083,7 @@ sub init_linker {
 
 Eliminate the macros in the output to the MMS/MMK file.
 
-(File::Spec::VMS used to do this for us, but it's being removed)
+(L<File::Spec::VMS> used to do this for us, but it's being removed)
 
 =cut
 
@@ -2121,7 +2122,7 @@ identically named elements of C<%$self>, and returns the result
 as a file specification in Unix syntax.
 
 NOTE:  This is the canonical version of the method.  The version in
-File::Spec::VMS is deprecated.
+L<File::Spec::VMS> is deprecated.
 
 =cut
 
@@ -2183,7 +2184,7 @@ force fixpath() to consider the path to be a directory or false to force
 it to be a file.
 
 NOTE:  This is the canonical version of the method.  The version in
-File::Spec::VMS is deprecated.
+L<File::Spec::VMS> is deprecated.
 
 =cut
 

--- a/lib/ExtUtils/MM_VOS.pm
+++ b/lib/ExtUtils/MM_VOS.pm
@@ -19,10 +19,10 @@ ExtUtils::MM_VOS - VOS specific subclass of ExtUtils::MM_Unix
 
 =head1 DESCRIPTION
 
-This is a subclass of ExtUtils::MM_Unix which contains functionality for
+This is a subclass of L<ExtUtils::MM_Unix> which contains functionality for
 VOS.
 
-Unless otherwise stated it works just like ExtUtils::MM_Unix
+Unless otherwise stated it works just like ExtUtils::MM_Unix.
 
 =head2 Overridden methods
 

--- a/lib/ExtUtils/MM_Win32.pm
+++ b/lib/ExtUtils/MM_Win32.pm
@@ -13,7 +13,7 @@ ExtUtils::MM_Win32 - methods to override UN*X behaviour in ExtUtils::MakeMaker
 
 =head1 DESCRIPTION
 
-See ExtUtils::MM_Unix for a documentation of the methods provided
+See L<ExtUtils::MM_Unix> for a documentation of the methods provided
 there. This package overrides the implementation of these methods, not
 the semantics.
 

--- a/lib/ExtUtils/MM_Win95.pm
+++ b/lib/ExtUtils/MM_Win95.pm
@@ -21,7 +21,7 @@ ExtUtils::MM_Win95 - method to customize MakeMaker for Win9X
 
 =head1 DESCRIPTION
 
-This is a subclass of ExtUtils::MM_Win32 containing changes necessary
+This is a subclass of L<ExtUtils::MM_Win32> containing changes necessary
 to get MakeMaker playing nice with command.com and other Win9Xisms.
 
 =head2 Overridden methods

--- a/lib/ExtUtils/MY.pm
+++ b/lib/ExtUtils/MY.pm
@@ -30,7 +30,7 @@ ExtUtils::MY - ExtUtils::MakeMaker subclass for customization
 
 B<FOR INTERNAL USE ONLY>
 
-ExtUtils::MY is a subclass of ExtUtils::MM.  Its provided in your
+ExtUtils::MY is a subclass of L<ExtUtils::MM>.  Its provided in your
 Makefile.PL for you to add and override MakeMaker functionality.
 
 It also provides a convenient alias via the MY class.

--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -1429,6 +1429,8 @@ seeks to handle all of these correctly. It is currently still not possible
 to portably use Unicode characters in module names, because this requires
 Perl to handle Unicode filenames, which is not yet the case on Windows.
 
+See L<ExtUtils::MakeMaker::FAQ> for details of the design and usage.
+
 =head2 How To Write A Makefile.PL
 
 See L<ExtUtils::MakeMaker::Tutorial>.
@@ -3039,7 +3041,8 @@ be linked.
 
 =item postamble
 
-Anything put here will be passed to MY::postamble() if you have one.
+Anything put here will be passed to
+L<MY::postamble()|ExtUtils::MM_Any/postamble (o)> if you have one.
 
 =item realclean
 
@@ -3086,7 +3089,7 @@ or you can edit the default by saying something like:
 
 If you are running experiments with embedding perl as a library into
 other applications, you might find MakeMaker is not sufficient. You'd
-better have a look at ExtUtils::Embed which is a collection of utilities
+better have a look at L<ExtUtils::Embed> which is a collection of utilities
 for embedding.
 
 If you still need a different solution, try to develop another
@@ -3150,7 +3153,7 @@ override or create an attribute you would say something like
 =head2 Distribution Support
 
 For authors of extensions MakeMaker provides several Makefile
-targets. Most of the support comes from the ExtUtils::Manifest module,
+targets. Most of the support comes from the L<ExtUtils::Manifest> module,
 where additional documentation can be found.
 
 =over 4
@@ -3158,13 +3161,13 @@ where additional documentation can be found.
 =item    make distcheck
 
 reports which files are below the build directory but not in the
-MANIFEST file and vice versa. (See ExtUtils::Manifest::fullcheck() for
+MANIFEST file and vice versa. (See L<ExtUtils::Manifest/fullcheck> for
 details)
 
 =item    make skipcheck
 
 reports which files are skipped due to the entries in the
-C<MANIFEST.SKIP> file (See ExtUtils::Manifest::skipcheck() for
+C<MANIFEST.SKIP> file (See L<ExtUtils::Manifest/skipcheck> for
 details)
 
 =item    make distclean
@@ -3181,7 +3184,7 @@ C<*.bak>, C<*.old> and C<*.orig>
 =item    make manifest
 
 rewrites the MANIFEST file, adding all remaining files found (See
-ExtUtils::Manifest::mkmanifest() for details)
+L<ExtUtils::Manifest/mkmanifest> for details)
 
 =item    make distdir
 

--- a/lib/ExtUtils/MakeMaker/FAQ.pod
+++ b/lib/ExtUtils/MakeMaker/FAQ.pod
@@ -12,7 +12,7 @@ ExtUtils::MakeMaker::FAQ - Frequently Asked Questions About MakeMaker
 
 =head1 DESCRIPTION
 
-FAQs, tricks and tips for C<ExtUtils::MakeMaker>.
+FAQs, tricks and tips for L<ExtUtils::MakeMaker>.
 
 
 =head2 Module Installation
@@ -569,7 +569,7 @@ What most people need to know (superclasses on top.)
                 |
                MY
 
-The object actually used is of the class MY which allows you to
+The object actually used is of the class L<MY|ExtUtils::MY> which allows you to
 override bits of MakeMaker inside your Makefile.PL by declaring
 MY::foo() methods.
 
@@ -600,24 +600,24 @@ NOTE: Yes, this is a mess.  See
 L<http://archive.develooper.com/makemaker@perl.org/msg00134.html>
 for some history.
 
-NOTE: When ExtUtils::MM is loaded it chooses a superclass for MM from
+NOTE: When L<ExtUtils::MM> is loaded it chooses a superclass for MM from
 amongst the ExtUtils::MM_* modules based on the current operating
 system.
 
 NOTE: ExtUtils::MM_{Current OS} represents one of the ExtUtils::MM_*
-modules except ExtUtils::MM_Any chosen based on your operating system.
+modules except L<ExtUtils::MM_Any> chosen based on your operating system.
 
 NOTE: The main object used by MakeMaker is a PACK### object, *not*
-ExtUtils::MakeMaker.  It is, effectively, a subclass of MY,
-ExtUtils::Makemaker, ExtUtils::Liblist and ExtUtils::MM_{Current OS}
+L<ExtUtils::MakeMaker>.  It is, effectively, a subclass of L<MY|ExtUtils::MY>,
+L<ExtUtils::Makemaker>, L<ExtUtils::Liblist> and ExtUtils::MM_{Current OS}
 
-NOTE: The methods in MY are simply copied into PACK### rather than
-MY being a superclass of PACK###.  I don't remember the rationale.
+NOTE: The methods in L<MY|ExtUtils::MY> are simply copied into PACK### rather
+than MY being a superclass of PACK###.  I don't remember the rationale.
 
-NOTE: ExtUtils::Liblist should be removed from the inheritance hiearchy
+NOTE: L<ExtUtils::Liblist> should be removed from the inheritance hiearchy
 and simply be called as functions.
 
-NOTE: Modules like File::Spec and Exporter have been omitted for clarity.
+NOTE: Modules like L<File::Spec> and L<Exporter> have been omitted for clarity.
 
 
 =head2 The MM_* hierarchy
@@ -632,12 +632,13 @@ NOTE: Modules like File::Spec and Exporter have been omitted for clarity.
                               |    |
                               MM_Any
 
-NOTE: Each direct MM_Unix subclass is also an MM_Any subclass.  This
+NOTE: Each direct L<MM_Unix|ExtUtils::MM_Unix> subclass is also an
+L<MM_Any|ExtUtils::MM_Any> subclass.  This
 is a temporary hack because MM_Unix overrides some MM_Any methods with
 Unix specific code.  It allows the non-Unix modules to see the
 original MM_Any implementations.
 
-NOTE: Modules like File::Spec and Exporter have been omitted for clarity.
+NOTE: Modules like L<File::Spec> and L<Exporter> have been omitted for clarity.
 
 =head1 PATCHING
 


### PR DESCRIPTION
Lots of EUMM documentation references other modules or even specific documentation but doesn't link to it. This adds crosslinks wherever it seems appropriate so people reading the documentation online can easily follow to referenced documentation.