### PR TITLE
Update referenced modules for new distributions

### DIFF
--- a/lib/ExtUtils/MakeMaker/Tutorial.pod
+++ b/lib/ExtUtils/MakeMaker/Tutorial.pod
@@ -205,7 +205,8 @@ L<perlmodstyle> gives stylistic help writing a module.
 L<perlnewmod> gives more information about how to write a module.
 
 There are modules to help you through the process of writing a module:
-L<ExtUtils::ModuleMaker>, L<Module::Install>, L<PAR>
+L<ExtUtils::ModuleMaker>, L<Module::Starter>, L<Minilla::Tutorial>,
+L<Dist::Milla::Tutorial>, L<Dist::Zilla::Starter>
 
 =cut
 


### PR DESCRIPTION
We should not reference Module::Install anymore. I don't think PAR needs to be mentioned here.