### PR TITLE
MM_Win32.pm: make can_dep_space check for short path support

### DIFF
--- a/lib/ExtUtils/MM_Win32.pm
+++ b/lib/ExtUtils/MM_Win32.pm
@@ -395,8 +395,15 @@ sub perl_script {
 }
 
 sub can_dep_space {
-    my $self = shift;
-    1; # with Win32::GetShortPathName
+    my ($self) = @_;
+    return 0 unless $self->can_load_xs;
+    require Win32;
+    require File::Spec;
+    my ($vol, $dir) = File::Spec->splitpath($INC{'ExtUtils/MakeMaker.pm'});
+    # can_dep_space via GetShortPathName, if short paths are supported
+    my $canary = Win32::GetShortPathName(File::Spec->catpath($vol, $dir, 'MakeMaker.pm'));
+    (undef, undef, my $file) = File::Spec->splitpath($canary);
+    return (length $file > 11) ? 0 : 1;
 }
 
 =item quote_dep


### PR DESCRIPTION
MM_Win32.pm's **can_dep_space()** always assumes that short path name support is present. But this is increasingly not the case. (It is disabled by default on non-C: drives on modern Windows releases.)

This commit makes can_dep_space() test whether short path name support is present.

Doing so fixes test failures (when short path name support is not present) in 02-dynamic.t. These failures come from MM_Win32.pm's **quote_dep()** being unable to handle the "type map" argument in the absence of short path support.

"type map" comes from MakeMaker::Test::Setup::XS, which will actually remove the space if the make flavour cannot handle spaces - but this happening depends upon can_dep_space() being accurate:
```
my $typemap = 'type map';
my $MM = MM->new({NAME=>'name', NORECURS=>1});
$typemap =~ s/ //g unless $MM->can_dep_space;
```