### PR TITLE
Always link to $Config{libs} on cygwin

### DIFF
--- a/lib/ExtUtils/MM_Cygwin.pm
+++ b/lib/ExtUtils/MM_Cygwin.pm
@@ -100,6 +100,16 @@ sub init_linker {
     $self->{EXPORT_LIST}  ||= '';
 }
 
+sub init_others {
+    my $self = shift;
+
+    $self->SUPER::init_others;
+
+    $self->{LDLOADLIBS} ||= $Config{perllibs};
+
+    return;
+}
+
 =item maybe_command
 
 Determine whether a file is native to Cygwin by checking whether it


### PR DESCRIPTION
This is intended to fix Perl/perl5#17805

WIP because it needs testing. @pjacklam would you be able to do that?