### PR TITLE
use $^V instead of PERL_VERSION once possible (5.10)

### DIFF
--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -3236,10 +3236,14 @@ PPD_PERLVERS
     }
 
     my $archname = $Config{archname};
-    if ("$]" >= 5.008) {
-        # archname did not change from 5.6 to 5.8, but those versions may
-        # not be not binary compatible so now we append the part of the
-        # version that changes when binary compatibility may change
+
+    # archname did not change from 5.6 to 5.8, but those versions may
+    # not be not binary compatible so now we append the part of the
+    # version that changes when binary compatibility may change
+    if( "$]" >= 5.010) {
+        $archname .= "-$^V->{version}->[0].$^V->{version}->[1]"; # v5.32.5 => 5.32
+    }
+    elsif ("$]" >= 5.008) {
         $archname .= "-$Config{PERL_REVISION}.$Config{PERL_VERSION}";
     }
     push @ppd_chunks, sprintf <<'PPD_OUT', $archname;

--- a/t/basic.t
+++ b/t/basic.t
@@ -132,8 +132,11 @@ like( $ppd_html, qr{^\s*<REQUIRE NAME="strict::" />}m,  '  <REQUIRE>' );
 unlike( $ppd_html, qr{^\s*<REQUIRE NAME="warnings::" />}m,  'no <REQUIRE> for build_require' );
 
 my $archname = $Config{archname};
-if( "$]" >= 5.008 ) {
-    # XXX This is a copy of the internal logic, so it's not a great test
+# XXX This is a copy of the internal logic, so it's not a great test
+if( "$]" >= 5.010) {
+    $archname .= "-$^V->{version}->[0].$^V->{version}->[1]";
+}
+elsif( "$]" >= 5.008 ) {
     $archname .= "-$Config{PERL_REVISION}.$Config{PERL_VERSION}";
 }
 like( $ppd_html, qr{^\s*<ARCHITECTURE NAME="$archname" />}m,


### PR DESCRIPTION
Due to issues with XS code assuming that the Perl major version is 5,
$CONFIG{PERL_VERSION} may be innacurate in a future version of Perl.
Instead, simply parse $^V and use that to produce the "ARCHITECTURE NAME"