### PR TITLE
Return hint file loading to quoted eval to make strict vars more useful

### DIFF
--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -1155,20 +1155,19 @@ sub check_hints {
 }
 
 sub _run_hintfile {
-    our $self;
-    local($self) = shift;       # make $self available to the hint file.
-    my($hint_file) = shift;
+    my ($self, $hint_file) = @_;
 
     local($@, $!);
     print "Processing hints file $hint_file\n" if $Verbose;
 
     # Just in case the ./ isn't on the hint file, which File::Spec can
     # often strip off, we bung the curdir into @INC
-    local @INC = (File::Spec->curdir, @INC);
-    my $ret = do $hint_file;
-    if( !defined $ret ) {
-        my $error = $@ || $!;
-        warn $error;
+    if(open(my $fh, '<', $hint_file)) {
+        eval join('', <$fh>);
+        warn "Failed to run hint file $hint_file: $@" if $@;
+    }
+    else {
+        warn "Could not open $hint_file for read: $!";
     }
 }
 

--- a/t/hints.t
+++ b/t/hints.t
@@ -61,9 +61,7 @@ CLOO
     local $SIG{__WARN__} = sub { $stderr .= join '', @_ };
 
     $mm->check_hints;
-    is( $stderr, <<OUT, 'hint files produce errors' );
-Argh!
-OUT
+    like( $stderr, qr{^Failed to run hint file hints\S+\.pl: Argh!\n\z}, 'hint files produce errors' );
 }
 
 END {


### PR DESCRIPTION
Return hint file loading to quoted eval to make strict vars more useful

This allows hints files to properly access $self without special magic.
Note that no change to the documentation is required because the
documentation has always stated that the code was 'evaled'.

An audit has already been done of the existing CPAN hint files. No files
use utf8 or appear to have anything beyond latin1 bytes. No BOMs were
seen either.

This change also reverts the behavior back to how it worked in perl 5.3.
It's not clear what protection we were trying to put in place at the
time. Before this change, hints have full access to the stash. Given
that $self is a variable local to the subroutine, there shouldn't need
to be any special protections. The only thing using do provides is
protection from modifying lexically scoped package variables. This
doesn't seem very valuable given that in exchange you have to say
no strict 'vars' in hints.pl to get strict to be on.

The failure message is also more clear and hopefully easier to find and
debug when it happens. Right now it is a little obscure in some make
output when it fails.