### PR TITLE
Make Mkbootstrap.pm strict.

### DIFF
--- a/lib/ExtUtils/Mkbootstrap.pm
+++ b/lib/ExtUtils/Mkbootstrap.pm
@@ -1,7 +1,6 @@
 package ExtUtils::Mkbootstrap;
 
-# There's just too much Dynaloader incest here to turn on strict vars.
-use strict 'refs';
+use strict;
 use warnings;
 
 our $VERSION = '7.47_11';
@@ -34,6 +33,7 @@ sub Mkbootstrap {
     if (-f "${baseext}_BS"){
 	$_ = "${baseext}_BS";
 	package DynaLoader; # execute code as if in DynaLoader
+	no strict 'vars';
 	local($osname, $dlsrc) = (); # avoid warnings
 	($osname, $dlsrc) = @Config::Config{qw(osname dlsrc)};
 	$bscode = "";
@@ -44,6 +44,7 @@ sub Mkbootstrap {
 
     if ($Config{'dlsrc'} =~ /^dl_dld/){
 	package DynaLoader;
+	no strict 'vars';
 	push(@dl_resolve_using, dl_findfile('-lc'));
     }
 


### PR DESCRIPTION
By explicitly referring to the DynaLoader package when referring to subs
or vars in that space, we can make Mkbootstrap.pm strict. This was already
being done in this package so we're just doing it in more places now.