### PR TITLE
Skip the failing dynamic vs static tests on Win32 in blead

### DIFF
--- a/t/lib/MakeMaker/Test/Setup/XS.pm
+++ b/t/lib/MakeMaker/Test/Setup/XS.pm
@@ -401,11 +401,17 @@ sub list_dynamic {
         $^O !~ m!^(VMS|aix)$! ? ([ 'subdirscomplex', '', '' ]) : (),
     ) : (), # DynaLoader different
     [ 'subdirs', '', '' ],
-    [ 'subdirsstatic', ' LINKTYPE=dynamic', ' LINKTYPE=dynamic' ],
-    [ 'subdirsstatic', ' dynamic', '_dynamic' ],
+    # https://github.com/Perl/perl5/issues/17601
+    # https://rt.cpan.org/Ticket/Display.html?id=115321
+    $^O ne 'MSWin32' ? (
+        [ 'subdirsstatic', ' LINKTYPE=dynamic', ' LINKTYPE=dynamic' ],
+        [ 'subdirsstatic', ' dynamic', '_dynamic' ],
+    ) : (),
     [ 'multi', '', '' ],
-    [ 'staticmulti', ' LINKTYPE=dynamic', ' LINKTYPE=dynamic' ],
-    [ 'staticmulti', ' dynamic', '_dynamic' ],
+    $^O ne 'MSWin32' ? (
+        [ 'staticmulti', ' LINKTYPE=dynamic', ' LINKTYPE=dynamic' ],
+        [ 'staticmulti', ' dynamic', '_dynamic' ],
+    ) : (),
     [ 'xsbuild', '', '' ],
     [ 'subdirsskip', '', '' ],
   );


### PR DESCRIPTION
Work around for https://github.com/Perl/perl5/issues/17601

See also https://rt.cpan.org/Ticket/Display.html?id=115321

This mirror's @tonycoz 's merge to blead found here https://github.com/Perl/perl5/pull/18157