### PR TITLE
fix PERL_CORE warnings from ExtUtils::CBuilder

### DIFF
--- a/t/lib/MakeMaker/Test/Utils.pm
+++ b/t/lib/MakeMaker/Test/Utils.pm
@@ -359,6 +359,8 @@ Returns true if there is a compiler available for XS builds.
 =cut
 
 sub have_compiler {
+    return 1 if $ENV{PERL_CORE};
+
     my $have_compiler = 0;
 
     in_dir(sub {


### PR DESCRIPTION
ExtUtils::CBuilder is used to detect if we have a compiler available.
It has some oddities and doesn't work well in parallel. We run it from a
temporary directory to avoid that. When doing a core build, and in a
temp directory, CBuilder sees PERL_CORE but can't find the perl source
and complains.

If we're running perl core tests, there's no real need to check for a
compiler. We can just assume one is available. Avoid CBuilder's mess and
just return true from our compiler check if running with PERL_CORE.

Fixes #372