### PR TITLE
clean up and improve MIN_PERL_VERSION handling

### DIFF
--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -511,50 +511,43 @@ sub new {
 
     check_hints($self);
 
-    if ( defined $self->{MIN_PERL_VERSION}
-          && $self->{MIN_PERL_VERSION} !~ /^v?[\d_\.]+$/ ) {
-      require version;
-      my $normal = eval {
-        local $SIG{__WARN__} = sub {
-            # simulate "use warnings FATAL => 'all'" for vintage perls
-            die @_;
-        };
-        version->new( $self->{MIN_PERL_VERSION} )
-      };
-      $self->{MIN_PERL_VERSION} = $normal if defined $normal && !$@;
-    }
+    if ( $self->{MIN_PERL_VERSION}) {
+        my $perl_version = $self->{MIN_PERL_VERSION};
+        if (ref $perl_version) {
+            # assume a version object
+        }
+        else {
+            $perl_version = eval {
+                local $SIG{__WARN__} = sub {
+                    # simulate "use warnings FATAL => 'all'" for vintage perls
+                    die @_;
+                };
+                version->new( $perl_version )->numify;
+            };
+            $perl_version =~ tr/_//d
+                if defined $perl_version;
+        }
 
-    # Translate X.Y.Z to X.00Y00Z
-    if( defined $self->{MIN_PERL_VERSION} ) {
-        $self->{MIN_PERL_VERSION} =~ s{ ^v? (\d+) \. (\d+) \. (\d+) $ }
-                                      {sprintf "%d.%03d%03d", $1, $2, $3}ex;
-    }
-
-    my $perl_version_ok = eval {
-        local $SIG{__WARN__} = sub {
-            # simulate "use warnings FATAL => 'all'" for vintage perls
-            die @_;
-        };
-        !$self->{MIN_PERL_VERSION} or $self->{MIN_PERL_VERSION} <= "$]"
-    };
-    if (!$perl_version_ok) {
-        if (!defined $perl_version_ok) {
-            die <<'END';
-MakeMaker FATAL: MIN_PERL_VERSION is not in a recognized format.
+        if (!defined $perl_version) {
+            # should this be a warning?
+            die sprintf <<'END', $self->{MIN_PERL_VERSION};
+MakeMaker FATAL: MIN_PERL_VERSION (%s) is not in a recognized format.
 Recommended is a quoted numerical value like '5.005' or '5.008001'.
 END
         }
-        elsif ($self->{PREREQ_FATAL}) {
-            die sprintf <<"END", $self->{MIN_PERL_VERSION}, $];
-MakeMaker FATAL: perl version too low for this distribution.
-Required is %s. We run %s.
+        elsif ($perl_version > "$]") {
+            my $message = sprintf <<'END', $perl_version, $];
+Perl version %s or higher required. We run %s.
 END
+            if ($self->{PREREQ_FATAL}) {
+                die "MakeMaker FATAL: $message";
+            }
+            else {
+                warn "Warning: $message";
+            }
         }
-        else {
-            warn sprintf
-                "Warning: Perl version %s or higher required. We run %s.\n",
-                $self->{MIN_PERL_VERSION}, $];
-        }
+
+        $self->{MIN_PERL_VERSION} = $perl_version;
     }
 
     my %configure_att;         # record &{$self->{CONFIGURE}} attributes

--- a/t/min_perl_version.t
+++ b/t/min_perl_version.t
@@ -63,6 +63,7 @@ chdir 't';
 
 perl_lib();
 
+rmtree($DIRNAME);
 hash2files($DIRNAME, \%FILES);
 END {
     ok( chdir(File::Spec->updir), 'leaving dir' );
@@ -132,7 +133,7 @@ note "Argument verification"; {
     };
     ok( '' ne $warnings, 'MIN_PERL_VERSION=999999 triggers a warning' );
     is( $warnings,
-        "Warning: Perl version 999999 or higher required. We run $].\n",
+        "Warning: Perl version 999999.000 or higher required. We run $].\n",
                          '  with expected message text' );
     is( $@, '',          '  and without a hard failure' );
 
@@ -146,8 +147,7 @@ note "Argument verification"; {
     };
     is( $warnings, '', 'MIN_PERL_VERSION=999999 and PREREQ_FATAL: no warning' );
     is( $@, <<"END",   '  correct exception' );
-MakeMaker FATAL: perl version too low for this distribution.
-Required is 999999. We run $].
+MakeMaker FATAL: Perl version 999999.000 or higher required. We run $].
 END
 
     $warnings = '';
@@ -158,7 +158,7 @@ END
         );
     };
     is( $@, <<'END', 'Invalid MIN_PERL_VERSION is fatal' );
-MakeMaker FATAL: MIN_PERL_VERSION is not in a recognized format.
+MakeMaker FATAL: MIN_PERL_VERSION (foobar) is not in a recognized format.
 Recommended is a quoted numerical value like '5.005' or '5.008001'.
 END
 


### PR DESCRIPTION
Rather than having special handling for some formats in
MIN_PERL_VERSION, just use version.pm. We have a private implementation
always available even if the real version.pm isn't. This allows versions
like v5.10 or 5.008_001 to be supported.

This also adjusts the warnings and errors to be more consistent and
informative.

This addresses [RT#133489](https://rt.cpan.org/Ticket/Display.html?id=133489)
