### PR TITLE
disable strict when evaling hints files

### DIFF
--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -1160,10 +1160,10 @@ sub _run_hintfile {
     local($@, $!);
     print "Processing hints file $hint_file\n" if $Verbose;
 
-    # Just in case the ./ isn't on the hint file, which File::Spec can
-    # often strip off, we bung the curdir into @INC
     if(open(my $fh, '<', $hint_file)) {
-        eval join('', <$fh>);
+        my $hints_content = do { local $/; <$fh> };
+        no strict;
+        eval $hints_content;
         warn "Failed to run hint file $hint_file: $@" if $@;
     }
     else {


### PR DESCRIPTION
Hints files are very commonly written not expecting strict to be
enabled. Prior to PR#367, hints were processed with a 'do', so strict
would not be enabled.

Fixes [RT#133492](https://rt.cpan.org/Ticket/Display.html?id=133492)