### PR TITLE
fix loss of $Config{ccflags} on darwin

### DIFF
--- a/lib/ExtUtils/MM_Darwin.pm
+++ b/lib/ExtUtils/MM_Darwin.pm
@@ -2,6 +2,7 @@ package ExtUtils::MM_Darwin;
 
 use strict;
 use warnings;
+use Config;
 
 BEGIN {
     require ExtUtils::MM_Unix;
@@ -55,7 +56,7 @@ Over-ride Apple's automatic setting of -Werror
 sub cflags {
     my $self = shift;
 
-    $self->{CCFLAGS} .= ($self->{CCFLAGS} ? ' ' : '').'-Wno-error=implicit-function-declaration';
+    $self->{CCFLAGS} .= ($self->{CCFLAGS} ? ' ' : "$Config{ccflags} ").'-Wno-error=implicit-function-declaration';
 
     $self->SUPER::cflags(@_);
 }


### PR DESCRIPTION
This skips some of the cleanup that EU::MM_Unix::cflags does, it might be better to have an extra_cflags()* method to add the -Wno-error=... instead of using cflags as the original commit did, but this Works For Me.

*or whatever name