### PR TITLE
fix Darwin cflags override

### DIFF
--- a/lib/ExtUtils/MM_Darwin.pm
+++ b/lib/ExtUtils/MM_Darwin.pm
@@ -53,11 +53,22 @@ Over-ride Apple's automatic setting of -Werror
 =cut
 
 sub cflags {
-    my $self = shift;
+    my($self,$libperl)=@_;
+    return $self->{CFLAGS} if $self->{CFLAGS};
+    return '' unless $self->needs_linking();
 
-    $self->{CCFLAGS} .= ($self->{CCFLAGS} ? ' ' : '').'-Wno-error=implicit-function-declaration';
+    my $base = $self->SUPER::cflags($libperl);
 
-    $self->SUPER::cflags(@_);
+    foreach (split /\n/, $base) {
+        /^(\S*)\s*=\s*(\S*)$/ and $self->{$1} = $2;
+    };
+    $self->{CCFLAGS} .= " -Wno-error=implicit-function-declaration";
+
+    return $self->{CFLAGS} = qq{
+CCFLAGS = $self->{CCFLAGS}
+OPTIMIZE = $self->{OPTIMIZE}
+PERLTYPE = $self->{PERLTYPE}
+};
 }
 
 1;


### PR DESCRIPTION
The cflags method is what initially populates the internal CCFLAGS option
if it is not set. If we set it ourselves before calling the parent
cflags method, we don't pick up any of the values it wants to set in it.
This would prevent the hints from $Config{ccflags} being carried
through. In core, it would prevent Time::HiRes from building because of
the missing -DPERL_DARWIN option.

Follow the pattern of other OS cflags overrides and call the parent
cflags first, then modify its output and the values set.

This is an alternative to #379