### PR TITLE
check CPAN::Meta::Requirements capabilities rather than prereqs

### DIFF
--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -426,7 +426,10 @@ sub _has_cpan_meta_requirements {
     return eval {
       require CPAN::Meta::Requirements;
       CPAN::Meta::Requirements->VERSION(2.130);
-      require B; # CMR requires this, for core we have to too.
+      # Make sure vstrings can be handled. Some versions of CMR require B to
+      # do this, which won't be available in miniperl.
+      CPAN::Meta::Requirements->new->add_string_requirement('Module' => v1.2);
+      1;
     };
 }
 


### PR DESCRIPTION
CPAN::Meta::Requirements will load B to try to handle vstrings when
using pure-perl version.pm. This is an internal detail of CMR which may
not not hold true in the future. It would be preferable for it to work
without B so that CMR could be used under miniperl.

Rather than checking for B, check if CPAN::Meta::Requirements can handle
vstrings.