### PR TITLE
Improve dlopen check on MacOS

### DIFF
--- a/lib/ExtUtils/Liblist/Kid.pm
+++ b/lib/ExtUtils/Liblist/Kid.pm
@@ -174,8 +174,8 @@ sub _unix_os2_ext {
                 && -f ( $fullname = "$thispth/lib$thislib.$Config_dlext" ) )
             {
             }
-            elsif ( defined( $Config_dlext ) && $^O eq 'darwin' && require DynaLoader && defined &DynaLoader::dl_load_file
-                && DynaLoader::dl_load_file( $fullname = "$thispth/lib$thislib.$Config_dlext", 0 ) )
+            elsif ( $^O eq 'darwin' && require DynaLoader && defined &DynaLoader::dl_load_file
+                && DynaLoader::dl_load_file( $fullname = "$thispth/lib$thislib.$so", 0 ) )
             {
             }
             elsif ( -f ( $fullname = "$thispth/$thislib$Config_libext" ) ) {


### PR DESCRIPTION
Previously we accidentally checked for a .bundle, when we should be checking for a .dylib

Confirmation it works [here](https://github.com/Perl/perl5/pull/18407#issuecomment-748310125)