### PR TITLE
Fix warning from undefined thislib

### DIFF
--- a/lib/ExtUtils/Liblist/Kid.pm
+++ b/lib/ExtUtils/Liblist/Kid.pm
@@ -96,6 +96,8 @@ sub _unix_os2_ext {
             next;
         }
 
+        next unless defined $thislib;
+
         if ( $thislib =~ m!^-Wl,! ) {
             push( @extralibs,  $thislib );
             push( @ldloadlibs, $thislib );


### PR DESCRIPTION
```
===Use of uninitialized value $thislib in substitution (s///) at ../lib/ExtUtils/Liblist/Kid.pm line 72, <DATA> line 53.
Use of uninitialized value $thislib in pattern match (m//) at ../lib/ExtUtils/Liblist/Kid.pm line 99, <DATA> line 53.
Use of uninitialized value $thislib in substitution (s///) at ../lib/ExtUtils/Liblist/Kid.pm line 106, <DATA> line 53.
Use of uninitialized value $thislib in concatenation (.) or string at ../lib/ExtUtils/Liblist/Kid.pm line 114,
```