### PR TITLE
Use shellwords in ExtUtils::Liblist::Kid::_unix_os2_ext

### DIFF
--- a/lib/ExtUtils/Liblist/Kid.pm
+++ b/lib/ExtUtils/Liblist/Kid.pm
@@ -52,7 +52,7 @@ sub _unix_os2_ext {
     require Text::ParseWords;
 
     my ( @searchpath );    # from "-L/path" entries in $potential_libs
-    my ( @libpath ) = Text::ParseWords::quotewords( '\s+', 0, $Config{'libpth'} || '' );
+    my ( @libpath ) = Text::ParseWords::shellwords( $Config{'libpth'} || '' );
     my ( @ldloadlibs, @bsloadlibs, @extralibs, @ld_run_path, %ld_run_path_seen );
     my ( @libs,       %libs_seen );
     my ( $fullname,   @fullname );
@@ -65,7 +65,7 @@ sub _unix_os2_ext {
         $potential_libs =~ s/(^|\s)(-F)\s*(\S+)/$1-Wl,$2 -Wl,$3/g;
     }
 
-    foreach my $thislib ( Text::ParseWords::quotewords( '\s+', 0, $potential_libs) ) {
+    foreach my $thislib ( Text::ParseWords::shellwords($potential_libs) ) {
         my ( $custom_name ) = '';
 
         # Handle possible linker path arguments.


### PR DESCRIPTION
If `quotewords` is passed a string that ends with a space (including the string `" "` itself), it will return an `undef` as last value. This is not useful for nor expected by `ExtUtils::Liblist::Kid`. Instead, this changes it to use `shellwords`, which returns an empty list in this case.

This fixes #391