### PR TITLE
comparing inodes numerically is unsafe

### DIFF
--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -1315,7 +1315,7 @@ sub _fixin_replace_shebang {
             if ($self->maybe_command($origcmd) && grep { $_ eq $origdir } @absdirs) {
                 my ($odev, $oino) = stat $origcmd;
                 my ($idev, $iino) = stat $interpreter;
-                if ($odev == $idev && $oino == $iino) {
+                if ($odev == $idev && $oino eq $iino) {
                     warn "$origcmd is the same as $interpreter, leaving alone"
                         if $Verbose;
                     $interpreter = $origcmd;


### PR DESCRIPTION
On a 32-bit system with 64-bit inodes, recent-ish versions of perl
will return very large inode numbers as strings, and their numeric
value may be too large to be exactly represented as an NV.

This means comparing such inodes numerically may return them as equal
even when the actual inode number is different.

See https://github.com/Perl/perl5/pull/18788 for a case where this
has caused a problem.