### PR TITLE
Retrofit haikuports patchset to support haiku as a separated platform from BeOS

### DIFF
--- a/lib/ExtUtils/MM.pm
+++ b/lib/ExtUtils/MM.pm
@@ -61,7 +61,8 @@ if( $^O eq 'MSWin32' ) {
 $Is{UWIN}   = $^O =~ /^uwin(-nt)?$/;
 $Is{Cygwin} = $^O eq 'cygwin';
 $Is{NW5}    = $Config{osname} eq 'NetWare';  # intentional
-$Is{BeOS}   = ($^O =~ /beos/i or $^O eq 'haiku');
+$Is{BeOS}   = $^O =~ /beos/i;
+$Is{Haiku}  = $^O eq 'haiku';
 $Is{DOS}    = $^O eq 'dos';
 if( $Is{NW5} ) {
     $^O = 'NetWare';

--- a/lib/ExtUtils/MM_Haiku.pm
+++ b/lib/ExtUtils/MM_Haiku.pm
@@ -1,0 +1,63 @@
+package ExtUtils::MM_Haiku;
+
+use strict;
+use warnings;
+
+=head1 NAME
+
+ExtUtils::MM_Haiku - methods to override UN*X behaviour in ExtUtils::MakeMaker
+
+=head1 SYNOPSIS
+
+ use ExtUtils::MM_Haiku;    # Done internally by ExtUtils::MakeMaker if needed
+
+=head1 DESCRIPTION
+
+See ExtUtils::MM_Unix for a documentation of the methods provided
+there. This package overrides the implementation of these methods, not
+the semantics.
+
+=over 4
+
+=cut
+
+use ExtUtils::MakeMaker::Config;
+use File::Spec;
+use ExtUtils::MM_Unix;
+
+our @ISA = qw( ExtUtils::MM_Unix );
+our $VERSION = '7.63_02';
+$VERSION =~ tr/_//d;
+
+
+sub os_flavor {
+    return('Haiku');
+}
+
+sub init_main {
+    my $self = shift;
+
+    # switch to vendor directories if requested.
+    if ($ENV{'HAIKU_USE_VENDOR_DIRECTORIES'}) {
+        $self->{INSTALLDIRS} ||= 'vendor';
+    }
+
+    $self->SUPER::init_main();
+}
+
+sub init_others {
+    my $self = shift;
+
+    $self->SUPER::init_others();
+
+    # Don't use run-time paths for libraries required by dynamic
+    # modules on Haiku, as that wouldn't work should a library be moved
+    # (for instance because the package has been activated somewhere else).
+    $self->{LD_RUN_PATH} = "";
+
+    return;
+}
+
+1;
+__END__
+


### PR DESCRIPTION
Hello 😀 

I propose this change to retrofit the portions of haikuports patch related to EUMM. See [haikuports perl patchset](https://github.com/haikuports/haikuports/blob/master/dev-lang/perl/patches/perl-5.32.1.patchset#L186)

Haiku has now some differences versus BeOS (filesystem hierarchy conventions...) that justifies this new "platform variant".

I tested it with perl 5.34.0 but I'm not a haiku expert and the code is not mine but from @olta

@bingos How do you feel about this change ?



