### PR TITLE
Don't use canned libpth values

### DIFF
--- a/lib/ExtUtils/Liblist/Kid.pm
+++ b/lib/ExtUtils/Liblist/Kid.pm
@@ -58,6 +58,10 @@ sub _unix_os2_ext {
     my ( $fullname,   @fullname );
     my ( $pwd )   = cwd();    # from Cwd.pm
     my ( $found ) = 0;
+	if ($Config{gccversion}) {
+		chomp(my @incpath = grep s/^ //, grep { /^#include </ .. /^End of search / } `$Config{cc} -E -v - </dev/null 2>&1 >/dev/null`);
+		unshift @libpath, map { s{/include[^/]*}{/lib}; $_ } @incpath
+	}
 
     if ( $^O eq 'darwin' or $^O eq 'next' )  {
         # 'escape' Mach-O ld -framework and -F flags, so they aren't dropped later on


### PR DESCRIPTION
On many platforms, these can change with compiler upgrades. Instead of using the values that were valid when perl was configured, this will ask the compiler for the valid values if possible.