### PR TITLE
Add $(LDFLAGS) when linking binary modules

### DIFF
--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -1092,7 +1092,7 @@ sub xs_make_dynamic_lib {
     }
 
     push @m, sprintf <<'MAKE', $ld_run_path_shell, $ldrun, $dlsyms_arg, $ldfrom, $self->xs_obj_opt('$@'), $libs, $exportlist;
-	%s$(LD) %s $(LDDLFLAGS) %s %s $(OTHERLDFLAGS) %s $(MYEXTLIB) \
+	%s$(LD) %s $(LDDLFLAGS) %s %s $(LDFLAGS) $(OTHERLDFLAGS) %s $(MYEXTLIB) \
 	  $(PERL_ARCHIVE) %s $(PERL_ARCHIVE_AFTER) %s \
 	  $(INST_DYNAMIC_FIX)
 	$(CHMOD) $(PERM_RWX) $@


### PR DESCRIPTION
LDFLAGS as environment variable is commonly used to pass global linker
flags in distribution builds to specific components build systems.

E.g. Yocto project sets --hash-style --debug-prefix-map and other entries in there.
