### PR TITLE
Extend prereqs sort to work on EBCDIC 

### DIFF
--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -634,7 +634,7 @@ END
 
     if (%unsatisfied && $self->{PREREQ_FATAL}){
         my $failedprereqs = join "\n", map {"    $_ $unsatisfied{$_}"}
-                            sort { $a cmp $b } keys %unsatisfied;
+                            sort { lc $a cmp lc $b } keys %unsatisfied;
         die <<"END";
 MakeMaker FATAL: prerequisites not found.
 $failedprereqs
@@ -720,7 +720,7 @@ END
     # RT#91540 PREREQ_FATAL not recognized on command line
     if (%unsatisfied && $self->{PREREQ_FATAL}){
         my $failedprereqs = join "\n", map {"    $_ $unsatisfied{$_}"}
-                            sort { $a cmp $b } keys %unsatisfied;
+                            sort { lc $a cmp lc $b } keys %unsatisfied;
         die <<"END";
 MakeMaker FATAL: prerequisites not found.
 $failedprereqs

--- a/t/prereq.t
+++ b/t/prereq.t
@@ -133,10 +133,14 @@ ok( chdir 'Big-Dummy', "chdir'd to Big-Dummy" ) ||
             "strict"            => 99999,
         }
     );
-    is $warnings,
-    "Warning: prerequisite I::Do::Not::Exist 0 not found.\n".
-    sprintf("Warning: prerequisite strict 99999 not found. We have %s.\n",
-            $strict::VERSION), '2 bad prereq warnings';
+
+    my $strict_warn
+        = sprintf("Warning: prerequisite strict 99999 not found. We have %s.\n",
+                                                            $strict::VERSION);
+    # Done this way because EBCDIC sorts in a different order
+    ok(   $warnings =~ s/Warning: prerequisite I::Do::Not::Exist 0 not found\.\n//
+       && $warnings =~ s/\Q$strict_warn//
+       && $warnings eq "", '2 bad prereq warnings');
 
     $warnings = '';
     eval {


### PR DESCRIPTION
In EBCDIC, lowercase collates before upper (which, btw,  I think is more
natural).  Thus we get a different sorting order than on ASCII, unless
we sort on just one or the other case.  This commit sorts on lowercase.