### PR TITLE
Makefile overwrites /dev/null

### DIFF
--- a/lib/ExtUtils/MM_Any.pm
+++ b/lib/ExtUtils/MM_Any.pm
@@ -774,7 +774,7 @@ clean :: clean_subdirs
     # Leave Makefile.old around for realclean
     push @m, <<'MAKE';
 	  $(NOECHO) $(RM_F) $(MAKEFILE_OLD)
-	- $(MV) $(FIRST_MAKEFILE) $(MAKEFILE_OLD) $(DEV_NULL)
+	- $(MV) $(FIRST_MAKEFILE) $(MAKEFILE_OLD)
 MAKE
 
     push(@m, "\t$attribs{POSTOP}\n")   if $attribs{POSTOP};


### PR DESCRIPTION
When building LaTeXML from CPAN, the Makefile overwrites /dev/null under some circumstances. It is in the clean section and after some debugging I found this comes from [Makemaker](https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/blob/master/lib/ExtUtils/MM_Any.pm#L777).

`$(MV) $(FIRST_MAKEFILE) $(MAKEFILE_OLD) $(DEV_NULL)`

This line moves both FIRST_MAKEFILE and MAKEFILE_OLD to DEV_NULL and replaces it. [The comment above the block](https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/blob/master/lib/ExtUtils/MM_Any.pm#L774) let me assume that FIRST_MAKEFILE should be renamed to MAKEFILE_OLD. The DEV_NULL must be a mistake but I am a bit surprised because this line has not been changed in 18 years, so this bug is quite mature.