### PR TITLE
Only include existent directories in libpath

### DIFF
--- a/lib/ExtUtils/Liblist/Kid.pm
+++ b/lib/ExtUtils/Liblist/Kid.pm
@@ -62,6 +62,7 @@ sub _unix_os2_ext {
 		chomp(my @incpath = grep s/^ //, grep { /^#include </ .. /^End of search / } `$Config{cc} -E -v - </dev/null 2>&1 >/dev/null`);
 		unshift @libpath, map { s{/include[^/]*}{/lib}; $_ } @incpath
 	}
+	@libpath = grep -d, @libpath;
 
     if ( $^O eq 'darwin' or $^O eq 'next' )  {
         # 'escape' Mach-O ld -framework and -F flags, so they aren't dropped later on


### PR DESCRIPTION
Otherwise, one can try to open non-existent directories, leading to warnings about invalid dirhandles.

This fixes https://github.com/Perl/perl5/issues/19794