### PR TITLE
Revert "Return hint file loading to quoted eval to make strict vars m…

### DIFF
--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -1151,19 +1151,20 @@ sub check_hints {
 }
 
 sub _run_hintfile {
-    my ($self, $hint_file) = @_;
+    our $self;
+    local($self) = shift;       # make $self available to the hint file.
+    my($hint_file) = shift;
 
     local($@, $!);
     print "Processing hints file $hint_file\n" if $Verbose;
 
-    if(open(my $fh, '<', $hint_file)) {
-        my $hints_content = do { local $/; <$fh> };
-        no strict;
-        eval $hints_content;
-        warn "Failed to run hint file $hint_file: $@" if $@;
-    }
-    else {
-        warn "Could not open $hint_file for read: $!";
+    # Just in case the ./ isn't on the hint file, which File::Spec can
+    # often strip off, we bung the curdir into @INC
+    local @INC = (File::Spec->curdir, @INC);
+    my $ret = do $hint_file;
+    if( !defined $ret ) {
+        my $error = $@ || $!;
+        warn $error;
     }
 }
 

--- a/t/hints.t
+++ b/t/hints.t
@@ -61,8 +61,9 @@ CLOO
     local $SIG{__WARN__} = sub { $stderr .= join '', @_ };
 
     $mm->check_hints;
-    my $Escaped_Hint_File = quotemeta($Hint_File);
-    like( $stderr, qr{^Failed to run hint file $Escaped_Hint_File: Argh!\n\z}, 'hint files produce errors' );
+    is( $stderr, <<OUT, 'hint files produce errors' );
+Argh!
+OUT
 }
 
 END {


### PR DESCRIPTION
…ore useful"

This reverts commit 5490957e1b65009602369a08003b55f1df575b2a.

This change breaks perfectly legal and useful constructs, such as in https://github.com/Perl/perl5/pull/20267