### PR TITLE
use a poor mans tempdir logic for parallel tests

### DIFF
--- a/t/INST.t
+++ b/t/INST.t
@@ -76,7 +76,7 @@ is( !!$mm->{PERL_CORE}, !!$ENV{PERL_CORE}, 'PERL_CORE' );
 
 my($perl_src, $mm_perl_src);
 if( $ENV{PERL_CORE} ) {
-    $perl_src = File::Spec->catdir($Updir, $Updir, $Updir, $Updir, $Updir);
+    $perl_src = File::Spec->catdir($Updir, $Updir, $Updir, $Updir, $Updir, $Updir);
     $perl_src = File::Spec->canonpath($perl_src);
     $mm_perl_src = File::Spec->canonpath($mm->{PERL_SRC});
 }
@@ -84,7 +84,7 @@ else {
     $mm_perl_src = $mm->{PERL_SRC};
 }
 
-is( $mm_perl_src, $perl_src,     'PERL_SRC' );
+is( $mm_perl_src, $perl_src,     "PERL_SRC" );
 
 
 # PERM_*

--- a/t/INST_PREFIX.t
+++ b/t/INST_PREFIX.t
@@ -109,7 +109,7 @@ is( !!$mm->{PERL_CORE}, !!$ENV{PERL_CORE}, 'PERL_CORE' );
 
 my($perl_src, $mm_perl_src);
 if( $ENV{PERL_CORE} ) {
-    $perl_src = File::Spec->catdir($Updir, $Updir, $Updir, $Updir, $Updir);
+    $perl_src = File::Spec->catdir($Updir, $Updir, $Updir, $Updir, $Updir, $Updir);
     $perl_src = File::Spec->canonpath($perl_src);
     $mm_perl_src = File::Spec->canonpath($mm->{PERL_SRC});
 }

--- a/t/lib/MakeMaker/Test/Setup/BFD.pm
+++ b/t/lib/MakeMaker/Test/Setup/BFD.pm
@@ -103,11 +103,20 @@ END
 
             );
 
+my $tmpdir;
 
 # if given args, those are inserted as components in resulting path, eg:
 # setup_recurs('dir') means instead of creating Big-Dummy/*, dir/Big-Dummy/*
 sub setup_recurs {
-    while(my($file, $text) = each %Files) {
+    my @chrs=("A".."Z",0-9);
+    # annoyingly we cant use File::Temp here as it drags in XS code
+    # and we run under blocks to prevent XS code loads. This is a minimal
+    # patch to fix the issue.
+    $tmpdir = join "", "./temp-$$-", map { $chrs[rand(@chrs)] } 1..8;
+    mkdir($tmpdir) or die "Failed to create '$tmpdir': $!";
+    chdir($tmpdir) or die "Failed to chdir '$tmpdir': $!";
+    foreach my $file (sort keys %Files) {
+        my $text = $Files{$file};
         # Convert to a relative, native file path.
         $file = File::Spec->catfile(File::Spec->curdir, @_, split m{\/}, $file);
         $file = File::Spec->rel2abs($file);
@@ -131,9 +140,11 @@ sub teardown_recurs {
     foreach my $file (keys %Files) {
         my $dir = dirname($file);
         if( -e $dir ) {
-            rmtree($dir) || return;
+            rmtree($dir) or next;
         }
     }
+    chdir("..");
+    rmtree($tmpdir);
     return 1;
 }
 


### PR DESCRIPTION
In core we want to run the tests in parallel. The tests in EUMM are not parallel safe as they all use the same directory for BFD and then the teardown from one affects the other, etc. This adds a poor mans temporary directory so each test invocation gets its own copy of the BFD directory. This has been tested in core builds already, and migrated to the master repo for EUMM from there.

This should fix https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/issues/425
See also: https://github.com/Perl/perl5/pull/20643