### PR TITLE
t/eu_command.t - sleep longer to make cygwin happy

### DIFF
--- a/t/eu_command.t
+++ b/t/eu_command.t
@@ -67,7 +67,14 @@ BEGIN {
 
     my ($now) = time;
     utime ($now, $now, $ARGV[0]);
-    sleep 2;
+
+    sleep 3; # note this affects the "newer file created"
+             # we used to sleep 2, but with the vagaries of sleep
+             # this meant that occasionally that test would fail
+             # on cygwin, by virtue of seeing only a one second
+             # difference. Sleeping 3 seconds should ensure
+             # that we get at least 2 seconds difference for
+             # that test.
 
     # Just checking modify time stamp, access time stamp is set
     # to the beginning of the day in Win95.


### PR DESCRIPTION
We do a sleep 2 and then expect to see a 2 second difference in the "newer file created" test, but sleep 2 does not necessarily achieve a 2 second file differences. Upping the sleep call to 3 seconds should ensure we see at least 2 seconds difference on operating systems like cygwin.