### PR TITLE
smoke-windows-cygwin.yml - setup safe.directory early

### DIFF
--- a/.github/workflows/smoke-windows-cygwin.yml
+++ b/.github/workflows/smoke-windows-cygwin.yml
@@ -14,7 +14,9 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - run: git config --global core.autocrlf false
+      - run: |
+          git config --global core.autocrlf false
+          git config --global --add safe.directory /cygdrive/d/a/ExtUtils-MakeMaker/ExtUtils-MakeMaker
       - uses: actions/checkout@master
         with:
             fetch-depth: 10


### PR DESCRIPTION
Hopefully this fixes:

    error: could not lock config file /home/runneradmin/.gitconfig: No such file or directory
    fatal: detected dubious ownership in repository at '/cygdrive/d/a/ExtUtils-MakeMaker/ExtUtils-MakeMaker'
    To add an exception for this directory, call:

            git config --global --add safe.directory /cygdrive/d/a/ExtUtils-MakeMaker/ExtUtils-MakeMaker
    Error: Process completed with exit code 128.