### PR TITLE
ci: Add system wide safe.directory

### DIFF
--- a/.github/workflows/smoke-windows-cygwin.yml
+++ b/.github/workflows/smoke-windows-cygwin.yml
@@ -31,7 +31,7 @@ jobs:
         shell: cmd
         run: |
             path c:\tools\cygwin\bin;c:\tools\cygwin\usr\bin
-            git config --global --add safe.directory /cygdrive/d/a/ExtUtils-MakeMaker/ExtUtils-MakeMaker
+            git config --system --add safe.directory /cygdrive/d/a/ExtUtils-MakeMaker/ExtUtils-MakeMaker
             git checkout --force
       - name: Configure
         shell: cmd


### PR DESCRIPTION
Apparently there is no user git config as with `--global` we get:

    error: could not lock config file /home/runneradmin/.gitconfig: No such file or directory

It shouldn't hurt to use `--system` here.

Fixes #428 