### PR TITLE
fix MIN_PERL_VERSION for perl versions with underscores

### DIFF
--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -525,7 +525,10 @@ sub new {
                     # simulate "use warnings FATAL => 'all'" for vintage perls
                     die @_;
                 };
-                version->new( $perl_version )->numify;
+                my $v = version->new($perl_version);
+                # we care about parse issues, not numify warnings
+                no warnings;
+                $v->numify;
             };
             $perl_version =~ tr/_//d
                 if defined $perl_version;

--- a/t/min_perl_version.t
+++ b/t/min_perl_version.t
@@ -17,7 +17,7 @@ use ExtUtils::MM;
 use Test::More
     !MM->can_run(make()) && $ENV{PERL_CORE} && $Config{'usecrosscompile'}
     ? (skip_all => "cross-compiling and make not available")
-    : (tests => 35);
+    : (tests => 37);
 use File::Path;
 
 use ExtUtils::MakeMaker;
@@ -121,6 +121,17 @@ note "Argument verification"; {
         );
     };
     is( $warnings, '', 'MIN_PERL_VERSION=X.Y.Z does not trigger a warning' );
+    is( $@, '',        '  nor a hard failure' );
+
+
+    $warnings = '';
+    eval {
+        WriteMakefile(
+            NAME             => 'Min::PerlVers',
+            MIN_PERL_VERSION => '5.005_04',
+        );
+    };
+    is( $warnings, '', 'MIN_PERL_VERSION=5.005_04 does not trigger a warning' );
     is( $@, '',        '  nor a hard failure' );
 
 


### PR DESCRIPTION
version->numify throws a warning when numifying alpha versions. numify throws warnings based on the caller's lexical warnings. We don't care. We just want the number.