### PR TITLE
t/.../More.pm - remove isn't: apostrophe as a package sep is deprecated

### DIFF
--- a/t/lib/Test/More.pm
+++ b/t/lib/Test/More.pm
@@ -382,8 +382,6 @@ sub isnt ($$;$) {
     return $tb->isnt_eq(@_);
 }
 
-*isn't = \&isnt;
-
 =item B<like>
 
   like( $got, qr/expected/, $test_name );


### PR DESCRIPTION
This silences warnings during test on perl 5.37.9 and later.