### PR TITLE
Revert changes to PERL_CORE and PERL_SRC handling

### DIFF
--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -1759,8 +1759,9 @@ sub init_CORE {
 
     # Are we building the core?
     $self->{PERL_CORE} = $ENV{PERL_CORE} unless exists $self->{PERL_CORE};
+    $self->{PERL_CORE} = 0               unless defined $self->{PERL_CORE};
 
-    if ((!defined $self->{PERL_CORE} || $self->{PERL_CORE}) && !$self->{PERL_SRC}){
+    unless ($self->{PERL_SRC}){
         foreach my $dir_count (1..8) { # 8 is the VMS limit for nesting
             my $dir = $self->catdir(($Updir) x $dir_count);
 
@@ -1769,7 +1770,6 @@ sub init_CORE {
                 -f $self->catfile($dir,"lib","strict.pm")
             ) {
                 $self->{PERL_SRC} = $dir ;
-                $self->{PERL_CORE} = 1;
                 last;
             }
         }

--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -225,7 +225,7 @@ sub cflags {
     # with the warning flags, but NOT the -std=c89 flags (the latter
     # would break using any system header files that are strict C99).
     my @ccextraflags = qw(ccwarnflags);
-    if ($self->{PERL_CORE}) {
+    if ($ENV{PERL_CORE}) {
       for my $x (@ccextraflags) {
         if (exists $Config{$x}) {
           $cflags{$x} = $Config{$x};
@@ -1748,47 +1748,13 @@ sub init_DIRFILESEP {
 }
 
 
-=item init_CORE
-
-Initializes PERL_CORE and PERL_SRC.
-
-=cut
-
-sub init_CORE {
-    my ($self) = @_;
-
-    # Are we building the core?
-    $self->{PERL_CORE} = $ENV{PERL_CORE} unless exists $self->{PERL_CORE};
-    $self->{PERL_CORE} = 0               unless defined $self->{PERL_CORE};
-
-    unless ($self->{PERL_SRC}){
-        foreach my $dir_count (1..8) { # 8 is the VMS limit for nesting
-            my $dir = $self->catdir(($Updir) x $dir_count);
-
-            if (-f $self->catfile($dir,"config_h.SH")   &&
-                -f $self->catfile($dir,"perl.h")        &&
-                -f $self->catfile($dir,"lib","strict.pm")
-            ) {
-                $self->{PERL_SRC} = $dir ;
-                last;
-            }
-        }
-    }
-
-    warn "PERL_CORE is set but I can't find your PERL_SRC!\n"
-        if $self->{PERL_CORE} and !$self->{PERL_SRC};
-
-    return;
-}
-
-
 =item init_main
 
 Initializes AR, AR_STATIC_ARGS, BASEEXT, CONFIG, DISTNAME, DLBASE,
 EXE_EXT, FULLEXT, FULLPERL, FULLPERLRUN, FULLPERLRUNINST, INST_*,
 INSTALL*, INSTALLDIRS, LIB_EXT, LIBPERL_A, MAP_TARGET, NAME,
 OBJ_EXT, PARENT_NAME, PERL, PERL_ARCHLIB, PERL_INC, PERL_LIB,
-PERLRUN, PERLRUNINST, PREFIX, VERSION,
+PERL_SRC, PERLRUN, PERLRUNINST, PREFIX, VERSION,
 VERSION_SYM, XS_VERSION.
 
 =cut
@@ -1838,6 +1804,23 @@ sub init_main {
     # *Real* information: where did we get these two from? ...
     my $inc_config_dir = dirname($INC{'Config.pm'});
     my $inc_carp_dir   = dirname($INC{'Carp.pm'});
+
+    unless ($self->{PERL_SRC}){
+        foreach my $dir_count (1..8) { # 8 is the VMS limit for nesting
+            my $dir = $self->catdir(($Updir) x $dir_count);
+
+            if (-f $self->catfile($dir,"config_h.SH")   &&
+                -f $self->catfile($dir,"perl.h")        &&
+                -f $self->catfile($dir,"lib","strict.pm")
+            ) {
+                $self->{PERL_SRC}=$dir ;
+                last;
+            }
+        }
+    }
+
+    warn "PERL_CORE is set but I can't find your PERL_SRC!\n" if
+      $self->{PERL_CORE} and !$self->{PERL_SRC};
 
     if ($self->{PERL_SRC}){
 	$self->{PERL_LIB}     ||= $self->catdir("$self->{PERL_SRC}","lib");
@@ -2176,6 +2159,10 @@ sub init_PERL {
     # * push quote inward by at least one character (or the drive prefix, if present)
     # * including any initial directory separator preserves the `file_name_is_absolute` property
     $self->{PERL} =~ s/^"(\S(:\\|:)?)/$1"/ if $self->is_make_type('dmake');
+
+    # Are we building the core?
+    $self->{PERL_CORE} = $ENV{PERL_CORE} unless exists $self->{PERL_CORE};
+    $self->{PERL_CORE} = 0               unless defined $self->{PERL_CORE};
 
     # Make sure perl can find itself before it's installed.
     my $lib_paths = $self->{UNINSTALLED_PERL} || $self->{PERL_CORE}

--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -44,6 +44,7 @@ our @EXPORT_OK = qw($VERSION &neatvalue &mkbootstrap &mksymlists
 # purged.
 my $Is_VMS     = $^O eq 'VMS';
 my $Is_Win32   = $^O eq 'MSWin32';
+our $UNDER_CORE = $ENV{PERL_CORE}; # needs to be our
 
 full_setup();
 
@@ -449,8 +450,6 @@ sub new {
     # object.  It will be blessed into a temp package later.
     bless $self, "MM";
 
-    $self->init_CORE;
-
     # Cleanup all the module requirement bits
     my %key2cmr;
     for my $key (qw(PREREQ_PM BUILD_REQUIRES CONFIGURE_REQUIRES TEST_REQUIRES)) {
@@ -509,7 +508,7 @@ sub new {
    }
 
     print "MakeMaker (v$VERSION)\n" if $Verbose;
-    if (-f "MANIFEST" && ! -f "Makefile" && ! $self->{PERL_CORE}){
+    if (-f "MANIFEST" && ! -f "Makefile" && ! $UNDER_CORE){
         check_manifest();
     }
 
@@ -618,7 +617,7 @@ END
             warn sprintf "Warning: prerequisite %s %s not found.\n",
               $prereq, $required_version
                    unless $self->{PREREQ_FATAL}
-                       or $self->{PERL_CORE};
+                       or $UNDER_CORE;
 
             $unsatisfied{$prereq} = 'not installed';
         }
@@ -630,7 +629,7 @@ END
             warn sprintf "Warning: prerequisite %s %s not found. We have %s.\n",
               $prereq, $required_version, ($pr_version || 'unknown version')
                   unless $self->{PREREQ_FATAL}
-                       or $self->{PERL_CORE};
+                       or $UNDER_CORE;
 
             $unsatisfied{$prereq} = $required_version || 'unknown version' ;
         }
@@ -1201,7 +1200,7 @@ sub mv_all_methods {
 sub skipcheck {
     my($self) = shift;
     my($section) = @_;
-    return 'skipped' if $section eq 'metafile' && $self->{PERL_CORE};
+    return 'skipped' if $section eq 'metafile' && $UNDER_CORE;
     if ($section eq 'dynamic') {
         print "Warning (non-fatal): Target 'dynamic' depends on targets ",
         "in skipped section 'dynamic_bs'\n"

--- a/t/prereq.t
+++ b/t/prereq.t
@@ -46,9 +46,8 @@ ok( chdir 'Big-Dummy', "chdir'd to Big-Dummy" ) ||
         }
         $warnings .= join '', @_;
     };
-
     # prerequisite warnings are disabled while building the perl core:
-    local $ENV{PERL_CORE} = 0;
+    local $ExtUtils::MakeMaker::UNDER_CORE = 0;
 
     WriteMakefile(
         NAME            => 'Big::Dummy',

--- a/t/vstrings.t
+++ b/t/vstrings.t
@@ -72,7 +72,7 @@ sub capture_make {
         $warnings .= join '', @_;
     };
 
-    local $ENV{PERL_CORE} = 0;
+    local $ExtUtils::MakeMaker::UNDER_CORE = 0;
 
     WriteMakefile(
         NAME      => 'VString::Test',


### PR DESCRIPTION
The changes made to the handling of PERL_CORE do not actually work properly in perl core. Various parts of the code are expecting to have the wrong understanding of PERL_CORE, or are using PERL_SRC for strange things.

I will try to reintroduce these changes in a way that works properly, but it will require a number of other fixes and modifications.