### PR TITLE
Remove support for dynamic loaders dropped by Dynaloader

### DIFF
--- a/lib/ExtUtils/Liblist/Kid.pm
+++ b/lib/ExtUtils/Liblist/Kid.pm
@@ -164,8 +164,7 @@ sub _unix_os2_ext {
                       } @fullname
                 )[0];
             }
-            elsif ( -f ( $fullname = "$thispth/lib$thislib.$so" )
-                && ( ( $Config{'dlsrc'} ne "dl_dld.xs" ) || ( $thislib eq "m" ) ) )
+            elsif ( -f ( $fullname = "$thispth/lib$thislib.$so" ))
             {
             }
             elsif (-f ( $fullname = "$thispth/lib${thislib}_s$Config_libext" )
@@ -245,8 +244,7 @@ sub _unix_os2_ext {
             }
 
             # We might be able to load this archive file dynamically
-            if (   ( $Config{'dlsrc'} =~ /dl_next/ && $Config{'osvers'} lt '4_0' )
-                || ( $Config{'dlsrc'} =~ /dl_dld/ ) )
+            if ($Config{'dlsrc'} =~ /dl_next/ && $Config{'osvers'} lt '4_0')
             {
 
                 # We push -l$thislib instead of $fullname because

--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -1925,13 +1925,6 @@ EOP
         $once_only{$m} = 1;
     }
 
-# This is too dangerous:
-#    if ($^O eq "next") {
-#	$self->{AR} = "libtool";
-#	$self->{AR_STATIC_ARGS} = "-o";
-#    }
-# But I leave it as a placeholder
-
     $self->{AR_STATIC_ARGS} ||= "cr";
 
     # These should never be needed

--- a/lib/ExtUtils/Mkbootstrap.pm
+++ b/lib/ExtUtils/Mkbootstrap.pm
@@ -42,12 +42,6 @@ sub Mkbootstrap {
 	shift @INC;
     }
 
-    if ($Config{'dlsrc'} =~ /^dl_dld/){
-	package DynaLoader;
-	no strict 'vars';
-	push(@dl_resolve_using, dl_findfile('-lc'));
-    }
-
     my(@all) = (@bsloadlibs, @DynaLoader::dl_resolve_using);
     my($method) = '';
     if (@all || (defined $DynaLoader::bscode && length $DynaLoader::bscode)){


### PR DESCRIPTION
[Remove support for GNU DLD](https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/pull/443/commits/81a332017e9342a2fdffa34ea263cd9df5a8b953)
[81a3320](https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/pull/443/commits/81a332017e9342a2fdffa34ea263cd9df5a8b953)

DynaLoader dropped support for GNU DLD in 2013 in Perl 5.19:

"The last release [of GNU DLD] was in 1996, and it has been superseded
by dlopen."

https://github.com/Perl/perl5/commit/1e5d7f54016618316299b1aacea865185fab5dd7

[Remove NeXT support](https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/pull/443/commits/5f9bfa5bbf54a6d1ddf3f630af0a5aafc5b2d52b)
[5f9bfa5](https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/pull/443/commits/5f9bfa5bbf54a6d1ddf3f630af0a5aafc5b2d52b)

DynaLoader dropped support for NeXT in 2014 in Perl 5.21

https://github.com/Perl/perl5/commit/f05550c064c2736017a5c65739d9eee325eed149