### PR TITLE
lib/ExtUtils/MM_Darwin.pm: Unbreak Perl build

### DIFF
--- a/lib/ExtUtils/MM_Darwin.pm
+++ b/lib/ExtUtils/MM_Darwin.pm
@@ -46,29 +46,4 @@ sub init_dist {
     $self->SUPER::init_dist(@_);
 }
 
-=head3 cflags
-
-Over-ride Apple's automatic setting of -Werror
-
-=cut
-
-sub cflags {
-    my($self,$libperl)=@_;
-    return $self->{CFLAGS} if $self->{CFLAGS};
-    return '' unless $self->needs_linking();
-
-    my $base = $self->SUPER::cflags($libperl);
-
-    foreach (split /\n/, $base) {
-        /^(\S*)\s*=\s*(\S*)$/ and $self->{$1} = $2;
-    };
-    $self->{CCFLAGS} .= " -Wno-error=implicit-function-declaration";
-
-    return $self->{CFLAGS} = qq{
-CCFLAGS = $self->{CCFLAGS}
-OPTIMIZE = $self->{OPTIMIZE}
-PERLTYPE = $self->{PERLTYPE}
-};
-}
-
 1;


### PR DESCRIPTION
On modern macOS the compiler defaults to '-Werror,-Wimplicit-function-declaration' This breaks the build on code which calls a function without a prototype (invalid in C99). Turning the check off with '-Wno-error=implicit-function-declaration' breaks the build of  Perl itself on legacy versions of Darwin with compilers which do not recognise the flags. Removing it allows Perl to once again build on Mac OS X as old as 10.4 with GCC 4.0.1.