### PR TITLE
t/04-xs-rpath-darwin.t: Need Darwin 9 minimum

### DIFF
--- a/t/04-xs-rpath-darwin.t
+++ b/t/04-xs-rpath-darwin.t
@@ -14,8 +14,12 @@ BEGIN {
     chdir 't' or die "chdir(t): $!\n";
     unshift @INC, 'lib/';
     use Test::More;
+    my ($osmajmin) = $Config{osvers} =~ /^(\d+\.\d+)/;
     if( $^O ne "darwin" ) {
         plan skip_all => 'Not darwin platform';
+    }
+    elsif ($^O eq 'darwin' && $osmajmin < 9) {
+	plan skip_all => 'For OS X Leopard and newer'
     }
     else {
         plan skip_all => 'Dynaloading not enabled'


### PR DESCRIPTION
-rpath is not support on toolchain of older Darwin versions. Fix for test part of issue #410