### PR TITLE
Fix STDIN input encoding for Windows

### DIFF
--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -216,9 +216,18 @@ sub prompt ($;$) {  ## no critic
         print "$def\n";
     }
     else {
+        my $codepage;
+        if ($Is_Win32) {
+            require Win32::Console;
+            require Encode;
+            my $codepage = Win32::GetConsoleCP();  # get the input code page
+        }
         $ans = <STDIN>;
         if( defined $ans ) {
             $ans =~ s{\015?\012$}{};
+            if ($Is_Win32) {
+                $ans = Encode::decode("cp". $codepage, $ans);
+            }
         }
         else { # user hit ctrl-D
             print "\n";


### PR DESCRIPTION
See https://github.com/cpan-testers/Test-Reporter-Transport-Metabase/issues/3 and https://stackoverflow.com/q/77123411/2173773. I believe this might fix [the issue](https://github.com/cpan-testers/Test-Reporter-Transport-Metabase/issues/3).