### PR TITLE
fix rpath issue on MacOS: rpath only accept a single path

### DIFF
--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -1062,7 +1062,8 @@ sub xs_make_dynamic_lib {
             # both clang and gcc support -Wl,-rpath, but only clang supports
             # -rpath so by using -Wl,-rpath we avoid having to check for the
             # type of compiler
-            $ldrun = qq{-Wl,-rpath,"$self->{LD_RUN_PATH}"};
+	    my @dirs = split ':', $self->{LD_RUN_PATH};
+	    $ldrun = join " ", map(qq{-Wl,-rpath,"$_"}, @dirs);
         }
     }
 


### PR DESCRIPTION
On MacOS (at least on MacOS 12 I tested), `rpath` should be a single path (instead of colon-separated paths). Otherwise, the loader might fail to load the dependencies. Check out this [blog](https://lekensteyn.nl/rpath.html#darwin-apple-macos). So the arguments passed to `g++` should look like this
```
LD_RUN_PATH="/path/aaa:/path/bbb" g++ -Wl,-rpath,"/path/aaa" -Wl,-rpath,"/path/bbb" ...
```