### PR TITLE
parse_version: handle "package version" syntax using the "hide from CPAN/PAUSE" hack

### DIFF
--- a/t/parse_version.t
+++ b/t/parse_version.t
@@ -79,6 +79,11 @@ END
 package Foo::100;
 our $VERSION = 2.34;
 END
+
+    $versions{<<'END'}                      = '1.23';
+package # hide from CPAN
+    Foo 1.23;
+END
 }
 
 if( "$]" >= 5.014 ) {


### PR DESCRIPTION
parse_version cannot parse a "package $package $version" if the line is broken after the "package" keyword, which is usually done for the "hide from CPAN" (or "hide from PAUSE") hack.

Sample affected module:
https://metacpan.org/release/PEVANS/IO-Async-0.803/source/lib/IO/Async/Internals/Connector.pm#L6 (The previous version found in the 0.802 distribution used the traditional package keyword, and there parse_version worked)

@andk @leonerd  FYI
