### PR TITLE
Adding link to `perlnewmod` to redirect people that needs skeleton module

### DIFF
--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -1370,6 +1370,12 @@ __END__
 
 ExtUtils::MakeMaker - Create a module Makefile
 
+==head1 SEE INSTEAD?
+
+This module is about creating a Makefile for an perl extension module
+from a Makefile.PL. If you are looking for creating skeleton module
+distribution for your new module, please see L<perlnewmod>
+
 =head1 SYNOPSIS
 
   use ExtUtils::MakeMaker;


### PR DESCRIPTION
When one is looking for creating new module, he will find ExtUtils::MakeMaker but not `perlnewmod`.

I guess such redirect will make life of many people more easy.

See #453 for more info