### PR TITLE
Fix DISTVNAME warnings more cleanly

### DIFF
--- a/lib/ExtUtils/MM_Any.pm
+++ b/lib/ExtUtils/MM_Any.pm
@@ -1302,7 +1302,7 @@ sub metafile_data {
     $meta_merge ||= {};
 
     my $version = _normalize_version($self->{VERSION});
-    my $unstable = $version =~ /_/ || ( defined $self->{DISTVNAME} and $self->{DISTVNAME} =~ /-TRIAL\d*$/ );
+    my $unstable = $version =~ /_/ || $self->{DISTVNAME} =~ /-TRIAL\d*$/;
     my $release_status = $unstable ? 'unstable' : 'stable';
     my %meta = (
         # required

--- a/t/meta_convert.t
+++ b/t/meta_convert.t
@@ -16,32 +16,33 @@ chdir $tmpdir or die "chdir $tmpdir: $!";
 my $EMPTY = qr/['"]?version['"]?\s*:\s*['"]['"]/;
 my @DATA = (
     [
-        [ DISTNAME => 'Net::FTP::Recursive', VERSION  => 'Recursive.pm', ],
+        [ DISTNAME => 'Net-FTP-Recursive', VERSION  => 'Recursive.pm', ],
         qr{Can't parse version 'Recursive.pm'},
         'VERSION => filename',
         $EMPTY,
     ],
     [
-        [ DISTNAME => 'Image::Imgur', VERSION  => 'undef', ],
+        [ DISTNAME => 'Image-Imgur', VERSION  => 'undef', ],
         qr{Can't parse version 'undef'},
         'no $VERSION in file -> VERSION=>"undef"',
         $EMPTY,
     ],
     [
-        [ DISTNAME => 'SQL::Library', VERSION  => 0.0.3, ],
+        [ DISTNAME => 'SQL-Library', VERSION  => 0.0.3, ],
         qr{Can't parse version '\x00\x00\x03'},
         "x.y.z version",
         $EMPTY,
     ],
     [
-        [ DISTNAME => 'Array::Suffix', VERSION  => '.5', ],
+        [ DISTNAME => 'Array-Suffix', VERSION  => '.5', ],
         qr{Can't parse version '.5'},
         ".5 version",
         $EMPTY,
     ],
     [
         [
-            DISTNAME   => 'Attribute::Signature',
+            DISTNAME   => 'Attribute-Signature',
+            DISTVNAME  => 'Attribute-Signature-1.23.tar.gz',
             META_MERGE => {
                 resources => {
                     repository         => 'http://github.com/chorny/Attribute-Signature',
@@ -55,7 +56,8 @@ my @DATA = (
     ],
     [
         [
-            DISTNAME   => 'CPAN::Testers::ParseReport',
+            DISTNAME   => 'CPAN-Testers-ParseReport',
+            DISTVNAME  => 'CPAN-Testers-ParseReport-2.34.tar.gz',
             VERSION    => '2.34',
             META_ADD => {
                 provides => {
@@ -72,7 +74,7 @@ my @DATA = (
     ],
     [
         [
-            DISTNAME   => 'Bad::License',
+            DISTNAME   => 'Bad-License',
             VERSION    => '2.34',
             LICENSE   => 'death and retribution',
         ],

--- a/t/metafile_data.t
+++ b/t/metafile_data.t
@@ -35,7 +35,9 @@ sub mymeta_ok {
 }
 
 my $new_mm = sub {
-    return bless { ARGS => {@_}, @_ }, 'ExtUtils::MM_Any';
+    my %args = @_;
+    $args{DISTVNAME} ||= "$args{DISTNAME}-$args{VERSION}.tar.gz";
+    return bless { ARGS => \%args, %args }, 'ExtUtils::MM_Any';
 };
 my @METASPEC14 = (
     'meta-spec'  => {
@@ -456,7 +458,7 @@ my @GENERIC_OUT = (
 note "CPAN::Meta bug using the module version instead of the meta spec version";
 {
     my $mm = $new_mm->(
-        NAME      => 'GD::Barcode::Code93',
+        DISTNAME  => 'GD-Barcode-Code93',
         AUTHOR    => 'Chris DiMartino',
         ABSTRACT  => 'Code 93 implementation of GD::Barcode family',
         PREREQ_PM => {


### PR DESCRIPTION
We shouldn't make the code uglier to take into account the shenanigans we play in our tests, we should make our tests better.

This is a follow-up to #456