### PR TITLE
Specify full path for FIXIN where possible

### DIFF
--- a/lib/ExtUtils/MM_Win32.pm
+++ b/lib/ExtUtils/MM_Win32.pm
@@ -142,11 +142,16 @@ sub init_tools {
     $self->{NOOP}     ||= 'rem';
     $self->{DEV_NULL} ||= '> NUL';
 
-    $self->{FIXIN}    ||= $self->{PERL_CORE} ?
-      "\$(PERLRUN) -I$self->{PERL_SRC}\\cpan\\ExtUtils-PL2Bat\\lib $self->{PERL_SRC}\\win32\\bin\\pl2bat.pl" :
-      -e "$Config{installscript}\\pl2bat.bat" ?
-      qq{"$Config{installscript}\\pl2bat.bat"} :
-      'pl2bat.bat';
+    if (!$self->{FIXIN}) {
+        if ($self->{PERL_CORE}) {
+            my $psrc = $self->{PERL_SRC};  #  shorten next line
+            $self->{FIXIN} = "\$(PERLRUN) -I${psrc}\\cpan\\ExtUtils-PL2Bat\\lib ${psrc}\\win32\\bin\\pl2bat.pl";
+        }
+        else {
+            my $p2bpath = "$Config{installscript}\\pl2bat.bat";
+            $self->{FIXIN} = -e $p2bpath ? qq{"$p2bpath"} : 'pl2bat.bat';
+        }
+    }
 
     $self->SUPER::init_tools;
 

--- a/lib/ExtUtils/MM_Win32.pm
+++ b/lib/ExtUtils/MM_Win32.pm
@@ -144,6 +144,8 @@ sub init_tools {
 
     $self->{FIXIN}    ||= $self->{PERL_CORE} ?
       "\$(PERLRUN) -I$self->{PERL_SRC}\\cpan\\ExtUtils-PL2Bat\\lib $self->{PERL_SRC}\\win32\\bin\\pl2bat.pl" :
+      -e "$Config{installscript}\\pl2bat.bat" ?
+      qq{"$Config{installscript}\\pl2bat.bat"} :
       'pl2bat.bat';
 
     $self->SUPER::init_tools;


### PR DESCRIPTION
Specifying the full path to pl2bat.bat makes it consistent with the other 
utilities specified in the generated makefiles and avoids possible issues 
with paths across MSYS/windows shells.  

The second commit makes the code somewhat longer than the ternary
but easier to read given it avoids listing the path twice.  However, I do 
appreciate that readability is a subjective thing.  I can elide it if it is 
deemed unnecessary.  

Updates #459 
