### PR TITLE
fix string comparisons with $] to use numeric comparison instead

### DIFF
--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -3251,7 +3251,10 @@ PPD_PERLVERS
     # archname did not change from 5.6 to 5.8, but those versions may
     # not be not binary compatible so now we append the part of the
     # version that changes when binary compatibility may change
-    if ("$]" >= 5.008) {
+    if ("$]" >= 5.010) {
+        $archname .= "-$^V->{version}->[0].$^V->{version}->[1]";
+    }
+    elsif ("$]" >= 5.008) {
         $archname .= "-$Config{api_revision}.$Config{api_version}";
     }
     push @ppd_chunks, sprintf <<'PPD_OUT', $archname;


### PR DESCRIPTION
The fix follows Zefram's suggestion from
https://www.nntp.perl.org/group/perl.perl5.porters/2012/05/msg186846.html

> On older perls, however, $] had a numeric value that was built up using
> floating-point arithmetic, such as 5+0.006+0.000002.  This would not
> necessarily match the conversion of the complete value from string form
> [perl #72210].  You can work around that by explicitly stringifying
> $] (which produces a correct string) and having *that* numify (to a
> correctly-converted floating point value) for comparison.  I cultivate
> the habit of always stringifying $] to work around this, regardless of
> the threshold where the bug was fixed.  So I'd write
>
>     use if "$]" >= 5.014, warnings => "non_unicode";

This ensures that the comparisons will still work when Perl's major version changes to anything greater than 9.