### PR TITLE
Reinstate %Recognized_Att_Keys - fix #312

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -137,6 +137,7 @@ t/prereq.t
 t/prereq_print.t
 t/problems.t
 t/prompt.t
+t/rec_att_keys.t
 t/recurs.t
 t/revision.t
 t/several_authors.t

--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -21,7 +21,7 @@ our @Get_from_Config;   # referenced by MM_Unix
 our @MM_Sections;
 our @Overridable;
 my @Prepend_parent;
-my %Recognized_Att_Keys;
+our %Recognized_Att_Keys;
 our %macro_fsentity; # whether a macro is a filesystem name
 our %macro_dep; # whether a macro is a dependency
 
@@ -1767,6 +1767,11 @@ recommends it (or you know what you're doing).
 The following attributes may be specified as arguments to WriteMakefile()
 or as NAME=VALUE pairs on the command line. Attributes that became
 available with later versions of MakeMaker are indicated.
+
+A computer-readable list of recognized attributes is available as
+C<%ExtUtils::MakeMakers::Recognized_Att_Keys>, supported since 7.72.  You
+can check whether a particular parameter is supported by the current
+version of ExtUtils::MakeMaker by checking whether it exists in the hash.
 
 In order to maintain portability of attributes with older versions of
 MakeMaker you may want to use L<App::EUMM::Upgrade> with your C<Makefile.PL>.

--- a/t/rec_att_keys.t
+++ b/t/rec_att_keys.t
@@ -1,0 +1,46 @@
+#!/usr/bin/perl -w
+
+# This script tests %ExtUtils::MakeMaker::Recognized_Att_Keys;
+
+use strict;
+use Test::More;
+
+# We don’t need to test all parameters; just enough to verify that the
+# mechanism is working.  This list is somewhat random, but it works.
+
+my @supported = qw(
+ ABSTRACT_FROM
+ AUTHOR
+ BUILD_REQUIRES
+ clean
+ dist
+ DISTNAME
+ DISTVNAME
+ LIBS
+ MAN3PODS
+ META_MERGE
+ MIN_PERL_VERSION
+ NAME
+ PL_FILES
+ PREREQ_PM
+ VERSION
+ VERSION_FROM
+);
+
+my @unsupported = qw(
+ WIBBLE
+ wump
+);
+
+plan tests => @supported+@unsupported;
+
+use ExtUtils::MakeMaker ();
+
+for (@supported) {
+    ok exists $ExtUtils::MakeMaker::Recognized_Att_Keys{$_},
+      "EUMM says it supports param '$_'";
+}
+for (@unsupported) {
+    ok !exists $ExtUtils::MakeMaker::Recognized_Att_Keys{$_},
+        "EUMM claims not to support param '$_'";
+}


### PR DESCRIPTION
This updates the commit in #312, changing the version to EUMM's next (7.72) and resolving the `MANIFEST` conflict. Supersedes and therefore closes #312. Sprout is still the author of the commit.