### PR TITLE
WriteEmptyMakefile should produce the same target types as WriteMakefile

### DIFF
--- a/lib/ExtUtils/MakeMaker.pm
+++ b/lib/ExtUtils/MakeMaker.pm
@@ -864,27 +864,27 @@ sub WriteEmptyMakefile {
     }
     open my $mfh, '>', $new or die "open $new for write: $!";
     print $mfh <<'EOP';
-all :
+all ::
 
 manifypods :
 
-subdirs :
+subdirs ::
 
-dynamic :
+dynamic ::
 
-static :
+static ::
 
-clean :
+clean ::
 
-install :
+install ::
 
 makemakerdflt :
 
-test :
+test ::
 
-test_dynamic :
+test_dynamic ::
 
-test_static :
+test_static ::
 
 EOP
     close $mfh or die "close $new for write: $!";


### PR DESCRIPTION
The target types created by WriteEmptyMakefile should match the ones created by WriteMakefile. This would ensure that any munging of the file to add rules could operate the same on each.