### PR TITLE
Fix pm_to_blib for VMS

### DIFF
--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -3191,10 +3191,10 @@ pm_to_blib : $(FIRST_MAKEFILE) $(TO_INST_PM)
 
     # VMS will swallow '' and PM_FILTER is often empty.  So use q[]
     my $pm_to_blib = $self->oneliner(<<CODE, ['-MExtUtils::Install']);
-\$i=0; \$i++ until \$i > \$#ARGV or \$ARGV[\$i] eq "--";
-die "Failed to find -- in ".join("|",\@ARGV) if \$i > \$#ARGV;
+\$i=0; \$n=\$#ARGV; \$i++ until \$i > \$n or \$ARGV[\$i] eq q{--};
+die q{Failed to find -- in }.join(q{|},\@ARGV) if \$i > \$n;
 \@parts=splice \@ARGV,0,\$i+1;
-pop \@parts; \$filter=join " ", map qq{"\$_"}, \@parts;
+pop \@parts; \$filter=join q{ }, map qq{"\$_"}, \@parts;
 pm_to_blib({\@ARGV}, '$autodir', \$filter, '\$(PERM_DIR)')
 CODE
     $pm_to_blib .= q[ $(PM_FILTER) --];


### PR DESCRIPTION
154730cb0da broke the core build on VMS.  The one-liner is not parseable and it turns out to be due to a bug in the make utility (MMK) wherein the comment character ('#') does not get ignored within a quoted string on a continuation line (it's fine on the first line of a rule).  So squirrel away $#ARGV and its '#' character in another variable on the first line, where it causes no trouble, then use the substitute on the second line.

Also, replace literal quote characters with the q operator where it's easy to do so; it's a lot easier to read and debug the generated code if you don't have to think about all of the quoting and escaping and interpolation rules regarding single and double quotes for Perl, the make utility, and the shell all at once.