### PR TITLE
Support 'class' VERSIONs, like 'package'

### DIFF
--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -3029,7 +3029,7 @@ sub parse_version {
         next if $inpod || /^\s*#/;
         chop;
         next if /^\s*(if|unless|elsif)/;
-        if ( m{^ \s* package \s+ \w[\w\:\']* \s+ (v?[0-9._]+) \s* (;|\{)  }x ) {
+        if ( m{^ \s* (?:package|class) \s+ \w[\w\:\']* \s+ (v?[0-9._]+) \s* (;|\{)  }x ) {
             no warnings;
             $result = $1;
         }

--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -3029,7 +3029,7 @@ sub parse_version {
         next if $inpod || /^\s*#/;
         chop;
         next if /^\s*(if|unless|elsif)/;
-        if ( m{^ \s* (?:package|class) \s+ \w[\w\:\']* \s+ (v?[0-9._]+) \s* (;|\{)  }x ) {
+        if ( m{^ \s* (?:package|class) \s+ \w[\w\:\']* \s+ (v?[0-9._]+) \s* (:|;|\{)  }x ) {
             no warnings;
             $result = $1;
         }

--- a/t/parse_version.t
+++ b/t/parse_version.t
@@ -123,6 +123,22 @@ if ( "$]" >= 5.038 ) {
     $versions{' class Foo::Bar v1.2.3 { }'   } = 'v1.2.3';
     $versions{"class Foo'Bar 1.23 { }"       } = '1.23';
     $versions{'class Foo 1.230 { }'          } = '1.230';
+
+    $versions{'class Foo 1.23 :isa(Bar);'              } = '1.23';
+    $versions{'class Foo::Bar 1.23 :isa(Bar);'         } = '1.23';
+    $versions{'class Foo v1.2.3 :isa(Bar);'            } = 'v1.2.3';
+    $versions{'class Foo::Bar v1.2.3 :isa(Bar);'       } = 'v1.2.3';
+    $versions{' class Foo::Bar v1.2.3 :isa(Bar);'      } = 'v1.2.3';
+    $versions{"class Foo'Bar 1.23 :isa(Bar);"          } = '1.23';
+    $versions{'class Foo 1.230 :isa(Bar);'             } = '1.230';
+
+    $versions{'class Foo 1.23 :isa(Bar) { }'           } = '1.23';
+    $versions{'class Foo::Bar 1.23 :isa(Bar) { }'      } = '1.23';
+    $versions{'class Foo v1.2.3 :isa(Bar) { }'         } = 'v1.2.3';
+    $versions{'class Foo::Bar v1.2.3 :isa(Bar) { }'    } = 'v1.2.3';
+    $versions{' class Foo::Bar v1.2.3 :isa(Bar) { }'   } = 'v1.2.3';
+    $versions{"class Foo'Bar 1.23 :isa(Bar) { }"       } = '1.23';
+    $versions{'class Foo 1.230 :isa(Bar) { }'          } = '1.230';
 }
 
 if ( "$]" < 5.012 ) {

--- a/t/parse_version.t
+++ b/t/parse_version.t
@@ -107,6 +107,24 @@ our $VERSION = 2.34;
 END
 }
 
+if ( "$]" >= 5.038 ) {
+    $versions{'class Foo 1.23;'              } = '1.23';
+    $versions{'class Foo::Bar 1.23;'         } = '1.23';
+    $versions{'class Foo v1.2.3;'            } = 'v1.2.3';
+    $versions{'class Foo::Bar v1.2.3;'       } = 'v1.2.3';
+    $versions{' class Foo::Bar v1.2.3;'      } = 'v1.2.3';
+    $versions{"class Foo'Bar 1.23;"          } = '1.23';
+    $versions{'class Foo 1.230;'             } = '1.230';
+
+    $versions{'class Foo 1.23 { }'           } = '1.23';
+    $versions{'class Foo::Bar 1.23 { }'      } = '1.23';
+    $versions{'class Foo v1.2.3 { }'         } = 'v1.2.3';
+    $versions{'class Foo::Bar v1.2.3 { }'    } = 'v1.2.3';
+    $versions{' class Foo::Bar v1.2.3 { }'   } = 'v1.2.3';
+    $versions{"class Foo'Bar 1.23 { }"       } = '1.23';
+    $versions{'class Foo 1.230 { }'          } = '1.230';
+}
+
 if ( "$]" < 5.012 ) {
   delete $versions{'$VERSION = -1.0'};
 }


### PR DESCRIPTION
This is supported by Perl since 5.38.