### PR TITLE
Disable XS prototypes by default

### DIFF
--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -3967,7 +3967,7 @@ sub tool_xsubpp {
     }
 
 
-    $self->{XSPROTOARG} = "" unless defined $self->{XSPROTOARG};
+    $self->{XSPROTOARG} = "-noprototypes" unless defined $self->{XSPROTOARG};
     $self->tool_xsubpp_emit($xsdir, \@tmdeps, \@tmargs);
 }
 


### PR DESCRIPTION
When neither `-prototypes` not `-noprototypes` is passed to `xsubpp`, it will require the XS files to contain a [PROTOTYPES statement](https://perldoc.perl.org/perlxs#The-PROTOTYPES:-Keyword). This is a compatibility feature that dealt with a [breaking change in January 1996](https://github.com/Perl/perl5/commit/8fc38fda), it long stopped having any purpose. Module::Build has disabled it since the very first version that supported XS (0.03 in 2001), and so should we.