### PR TITLE
Fix PERL_MM_SHEBANG when input script has args

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,7 @@
 
     Core fixes:
     - Disable XS prototypes by default
+    - Do not copy args when using PERL_MM_SHEBANG=relocatable
 
     Test fixes:
     - Make macros portably in basic.t

--- a/lib/ExtUtils/MM_Unix.pm
+++ b/lib/ExtUtils/MM_Unix.pm
@@ -1322,6 +1322,7 @@ sub _fixin_replace_shebang {
     my $interpreter;
     if ( defined $ENV{PERL_MM_SHEBANG} && $ENV{PERL_MM_SHEBANG} eq "relocatable" ) {
         $interpreter = "/usr/bin/env perl";
+        $arg = '';
     }
     elsif ( $cmd =~ m{^perl(?:\z|[^a-z])} ) {
         if ( $Config{startperl} =~ m,^\#!.*/perl, ) {


### PR DESCRIPTION
In _fixin_replace_shebang, empty the argument string when PERL_MM_SHEBANG=relocatable is set in the environment. Previously, if a script had a shebang such as "#!/usr/bin/env perl" already, it would become "#!/usr/bin/env perl perl"; on most systems, env will then try to run "perl perl" and fail. The same issue exists if the script had a shebang with any arguments.

Note that this occurs with the env utility before perl does its special argument-list-as-a-string handling. No arguments can be portably preserved when using this override.